### PR TITLE
Xcode.app will auto-populate this target reference

### DIFF
--- a/Brisk.xcodeproj/xcshareddata/xcschemes/Brisk.xcscheme
+++ b/Brisk.xcodeproj/xcshareddata/xcschemes/Brisk.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:Brisk.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C28001F01D148AB800569A72"
+               BuildableName = "BriskUITests.xctest"
+               BlueprintName = "BriskUITests"
+               ReferencedContainer = "container:Brisk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
upon opening the project for the first time. Might as well keep it.