### PR TITLE
Update menu bar icon to render as template

### DIFF
--- a/Brisk/Resources/Assets.xcassets/StatusItemIcon.imageset/Contents.json
+++ b/Brisk/Resources/Assets.xcassets/StatusItemIcon.imageset/Contents.json
@@ -18,5 +18,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
Without this setting, the icon renders as black even in dark mode.