### PR TITLE
Remove logout button keyboard shortcut

### DIFF
--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -893,10 +893,6 @@ DQ
                                 <buttonCell key="cell" type="push" title="Log Out" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jhy-5u-Yg5">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
-                                    <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                                    <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="logOut:" target="UrK-pc-2Bl" id="x0n-ce-CrD"/>


### PR DESCRIPTION
At some point during development I added command + enter as a keyboard
shortcut to logout. This makes the button blue and looks like pressing
enter will do it. We don't need to make it this easy to logout.

Closes https://github.com/br1sk/brisk/issues/26