### PR TITLE
Fix areas by product

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -60,16 +60,19 @@ final class RadarViewController: ViewController {
         super.viewDidLoad()
 
         self.setupTextViewDelegates()
-        self.areaPopUp.setItems(titles: Area.AlliOSAreas.map { $0.name })
         self.classificationPopUp.setItems(titles: Classification.All.map { $0.name })
         self.reproducibilityPopUp.setItems(titles: Reproducibility.All.map { $0.name })
         self.productPopUp.set(items: Product.All, getTitle: { $0.name }, getGroup: { $0.category })
+
+        let product = Product.All.first { $0.name == self.productPopUp.selectedTitle }!
+        self.updateAreas(with: product)
     }
 
     func restore(_ radar: Radar) {
         self.classificationPopUp.selectItem(withTitle: radar.classification.name)
         self.reproducibilityPopUp.selectItem(withTitle: radar.reproducibility.name)
         self.productPopUp.selectItem(withTitle: radar.product.name)
+        self.updateAreas(with: radar.product)
         if let area = radar.area {
             self.areaPopUp.selectItem(withTitle: area.name)
         }
@@ -92,7 +95,7 @@ final class RadarViewController: ViewController {
         let classification = Classification.All.first { $0.name == self.classificationPopUp.selectedTitle }!
         let reproducibility = Reproducibility.All
             .first { $0.name == self.reproducibilityPopUp.selectedTitle }!
-        let area = Area.AlliOSAreas.first { $0.name == self.areaPopUp.selectedTitle }!
+        let area = Area.areas(for: product).first { $0.name == self.areaPopUp.selectedTitle }!
 
         return Radar(
             classification: classification, product: product, reproducibility: reproducibility,
@@ -167,7 +170,7 @@ final class RadarViewController: ViewController {
 
     @IBAction private func productChanged(_ sender: NSPopUpButton) {
         let product = Product.All.first { $0.name == sender.selectedTitle }!
-        self.areaPopUp.isEnabled = product.appleIdentifier == Product.iOS.appleIdentifier
+        self.updateAreas(with: product)
     }
 
     @IBAction private func addAttachment(_ sender: NSButton) {
@@ -191,6 +194,12 @@ final class RadarViewController: ViewController {
                 alert.beginSheetModal(for: window, completionHandler: nil)
             }
         }
+    }
+
+    private func updateAreas(with product: Product) {
+        let areaNames = Area.areas(for: product).map { $0.name }
+        self.areaPopUp.setItems(titles: areaNames)
+        self.areaPopUp.isEnabled = !areaNames.isEmpty
     }
 
     private func showError(message: String) {

--- a/Brisk/Extensions/Radar+Serialization.swift
+++ b/Brisk/Extensions/Radar+Serialization.swift
@@ -49,8 +49,8 @@ extension Radar {
             ?? Classification.All.first!
         let reproducibility = Reproducibility.All.first { $0.appleIdentifier == reproducibilityID }
             ?? Reproducibility.All.first!
-        let area = Area.AlliOSAreas.first { $0.appleIdentifier == areaID } ?? Area.AlliOSAreas.first!
         let product = Product.All.first { $0.appleIdentifier == productID } ?? Product.All.first!
+        let area = Area.areas(for: product).first { $0.appleIdentifier == areaID }
 
         self.init(classification: classification, product: product, reproducibility: reproducibility,
                      title: title, description: description, steps: steps, expected: expected, actual: actual,

--- a/BriskTests/RadarSerializationTests.swift
+++ b/BriskTests/RadarSerializationTests.swift
@@ -13,11 +13,12 @@ final class RadarSerializationTests: XCTestCase {
     func testSerializingRadar() {
         let attachment = Attachment(filename: "foo.png", mimeType: "image/png",
                                     data: Data(base64Encoded: "")!)
+        let area = Area.areas(for: Product.iOS).first!
         let radar = Radar(
             classification: .Security, product: .iOS, reproducibility: .Always, title: "title",
             description: "description", steps: "steps", expected: "expected", actual: "actual",
             configuration: "config", version: "version", notes: "notes", attachments: [attachment],
-            area: Area(appleIdentifier: 1, name: "foo"), applicationID: "456", userID: "123"
+            area: area, applicationID: "456", userID: "123"
         )
 
         let json = try! radar.toData().toJSONDictionary() as NSDictionary?

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,7 +12,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Sonar:
-    :commit: 0a959ef8ed3f15c15217e560b37186239700cf3a
+    :commit: 97607c59a704f7642d23a2150f512d481d18150b
     :git: https://github.com/br1sk/Sonar.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
Previously the area field on Radar was only used for iOS. Now it's used
for multiple products, yet the items with the same names across products
don't particularly have the same IDs. This updates the area picker to be
populated by the areas per product, and cleared when switching to a
product with no areas.