### PR TITLE
Fix some area related bugs

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -34,7 +34,6 @@ final class RadarViewController: ViewController {
     private var validatables: [Validatable] {
         return [
             self.actualTextView,
-            self.areaPopUp,
             self.classificationPopUp,
             self.configurationTextField,
             self.descriptionTextView,
@@ -95,7 +94,7 @@ final class RadarViewController: ViewController {
         let classification = Classification.All.first { $0.name == self.classificationPopUp.selectedTitle }!
         let reproducibility = Reproducibility.All
             .first { $0.name == self.reproducibilityPopUp.selectedTitle }!
-        let area = Area.areas(for: product).first { $0.name == self.areaPopUp.selectedTitle }!
+        let area = Area.areas(for: product).first { $0.name == self.areaPopUp.selectedTitle }
 
         return Radar(
             classification: classification, product: product, reproducibility: reproducibility,


### PR DESCRIPTION
Before more than just the iOS product support areas, Brisk actually had
a bug where it was sending the last selected iOS area regardless of
product. This also meant it was saving the wrong area when saving the
json file.

Once we changed to having areas for some products, and not others, this
caused 2 new bugs.

- Validation would never pass for products without areas

This was caused because the areaPopUp was validated, but its title was
an empty string. It has now been removed from the validation list
(there's also a possible fix for this where pop up buttons are validated
by having a title, or being disabled)

- Brisk would crash when saving a radar for a product that didn't
support areas.

This was because we were always assuming the areaPopUp would have a
value, but it wouldn't for most products.