### PR TITLE
Open an untitled window on launch with dock icon

### DIFF
--- a/Brisk/AppDelegate.swift
+++ b/Brisk/AppDelegate.swift
@@ -17,7 +17,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
-        return false
+        return UserDefaults.standard.bool(forKey: Defaults.showDockIcon)
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {


### PR DESCRIPTION
Before brisk had the option of showing a dock icon, when launching it
into a menu bar icon, we wouldn't open a new window. This was because
menu bar apps should ideally be low key until you need them.

Once we added the preference for showing a dock icon we never rethought
this.

This updates the logic to open a new untitled window if you're showing
the dock icon.

Things to note about this API:

1. It's called before `didFinishLaunching`
2. We're not registering the defaults before accessing them
3. This should only matter if you don't have windows to reopen