### PR TITLE
Fix non-responsive menu bar on first launch

### DIFF
--- a/Brisk/AppDelegate.swift
+++ b/Brisk/AppDelegate.swift
@@ -5,11 +5,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet private var statusMenu: NSMenu!
     private var statusItem: NSStatusItem?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    func applicationWillFinishLaunching(_ notification: Notification) {
         self.registerDefaults()
-        StoryboardRouter.reloadTopWindowController()
         self.setupDockIcon()
         self.setupStatusItem()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        StoryboardRouter.reloadTopWindowController()
         GlobalHotKey.register()
     }
 


### PR DESCRIPTION
After launching brisk with the dock icon active, if you attempted to
click the menu bar immediately after it was launched, it would not be
interactive. To fix this you had to focus a different app, and then
refocus brisk.

This seemed to be caused by the setActivationPolicy call being in
applicationDidFinishLaunching rather than
applicationWillFinishLaunching. Moving this initialization there seems to
fix this issue.

https://stackoverflow.com/questions/33345686/cocoa-application-menu-bar-not-clickable