### PR TITLE
Remove ATS exceptions

### DIFF
--- a/Brisk/Resources/Info.plist
+++ b/Brisk/Resources/Info.plist
@@ -47,11 +47,6 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Brisk. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,6 @@
 
 - Remove unnecessary fields from `Info.plist`
   [change](https://github.com/br1sk/brisk/pull/72)
+
+- Remove App Transport Security exceptions
+  [change](https://github.com/br1sk/brisk/pull/73)


### PR DESCRIPTION
Not sure why this was necessary, it seems like it isn't anymore (if it
ever was).