### PR TITLE
Add logic for duping radar

### DIFF
--- a/Brisk.xcodeproj/project.pbxproj
+++ b/Brisk.xcodeproj/project.pbxproj
@@ -17,8 +17,21 @@
 		C20DDC1A1D167D5F0086D304 /* RadarDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20DDC191D167D5F0086D304 /* RadarDocument.swift */; };
 		C219CBD81D173602002F89FC /* NSStatusItem+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219CBD71D173602002F89FC /* NSStatusItem+Extension.swift */; };
 		C219CBDA1D1736EB002F89FC /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219CBD91D1736EB002F89FC /* Application.swift */; };
+		C23ED5061EFA14E1006988BA /* FileDuplicateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED5041EFA1174006988BA /* FileDuplicateViewController.swift */; };
+		C23ED5081EFA1FD1006988BA /* NSDocumentController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED5071EFA1FD1006988BA /* NSDocumentController+Extension.swift */; };
+		C23ED50A1EFA2362006988BA /* NSProgressIndicator+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED5091EFA2362006988BA /* NSProgressIndicator+Extension.swift */; };
+		C23ED50C1EFA2DA9006988BA /* RadarIDParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED50B1EFA2DA9006988BA /* RadarIDParsingTests.swift */; };
 		C255C4431DAB7A9C00383D0A /* ResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C255C4421DAB7A9C00383D0A /* ResultTests.swift */; };
+		C27694501EFCD461009C3FA1 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C276944F1EFCD461009C3FA1 /* StringExtensionTests.swift */; };
+		C27694521EFD094F009C3FA1 /* OpenRadar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27694511EFD094F009C3FA1 /* OpenRadar.swift */; };
+		C27694541EFD097C009C3FA1 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27694531EFD097C009C3FA1 /* String+Extension.swift */; };
+		C27694561EFD0BD4009C3FA1 /* openradarstrings.json in Resources */ = {isa = PBXBuildFile; fileRef = C27694551EFD0BD4009C3FA1 /* openradarstrings.json */; };
 		C27A5A171E721BD300391E63 /* Attachment+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27A5A161E721BD300391E63 /* Attachment+Serialization.swift */; };
+		C27DBF221EF8F039007666C3 /* OpenRadarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27DBF211EF8F039007666C3 /* OpenRadarTests.swift */; };
+		C27DBF241EF8F071007666C3 /* Radar+OpenRadar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27DBF231EF8F071007666C3 /* Radar+OpenRadar.swift */; };
+		C27DBF261EF8F12D007666C3 /* openradar.json in Resources */ = {isa = PBXBuildFile; fileRef = C27DBF251EF8F12D007666C3 /* openradar.json */; };
+		C27DBF281EF8F6E2007666C3 /* DictionaryExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27DBF271EF8F6E2007666C3 /* DictionaryExtensionTests.swift */; };
+		C27DBF2B1EF8F75C007666C3 /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27DBF2A1EF8F75C007666C3 /* Dictionary+Extension.swift */; };
 		C27F3B721D8B239B00EA3B7D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27F3B711D8B239B00EA3B7D /* Constants.swift */; };
 		C28001D91D148AB800569A72 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28001D81D148AB800569A72 /* AppDelegate.swift */; };
 		C28001DD1D148AB800569A72 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C28001DC1D148AB800569A72 /* Assets.xcassets */; };
@@ -72,8 +85,21 @@
 		C20DDC191D167D5F0086D304 /* RadarDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadarDocument.swift; sourceTree = "<group>"; };
 		C219CBD71D173602002F89FC /* NSStatusItem+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSStatusItem+Extension.swift"; sourceTree = "<group>"; };
 		C219CBD91D1736EB002F89FC /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
+		C23ED5041EFA1174006988BA /* FileDuplicateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDuplicateViewController.swift; sourceTree = "<group>"; };
+		C23ED5071EFA1FD1006988BA /* NSDocumentController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDocumentController+Extension.swift"; sourceTree = "<group>"; };
+		C23ED5091EFA2362006988BA /* NSProgressIndicator+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSProgressIndicator+Extension.swift"; sourceTree = "<group>"; };
+		C23ED50B1EFA2DA9006988BA /* RadarIDParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadarIDParsingTests.swift; sourceTree = "<group>"; };
 		C255C4421DAB7A9C00383D0A /* ResultTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTests.swift; sourceTree = "<group>"; };
+		C276944F1EFCD461009C3FA1 /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
+		C27694511EFD094F009C3FA1 /* OpenRadar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenRadar.swift; sourceTree = "<group>"; };
+		C27694531EFD097C009C3FA1 /* String+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		C27694551EFD0BD4009C3FA1 /* openradarstrings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = openradarstrings.json; sourceTree = "<group>"; };
 		C27A5A161E721BD300391E63 /* Attachment+Serialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Attachment+Serialization.swift"; sourceTree = "<group>"; };
+		C27DBF211EF8F039007666C3 /* OpenRadarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenRadarTests.swift; sourceTree = "<group>"; };
+		C27DBF231EF8F071007666C3 /* Radar+OpenRadar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Radar+OpenRadar.swift"; sourceTree = "<group>"; };
+		C27DBF251EF8F12D007666C3 /* openradar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = openradar.json; sourceTree = "<group>"; };
+		C27DBF271EF8F6E2007666C3 /* DictionaryExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionTests.swift; sourceTree = "<group>"; };
+		C27DBF2A1EF8F75C007666C3 /* Dictionary+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extension.swift"; sourceTree = "<group>"; };
 		C27F3B711D8B239B00EA3B7D /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		C28001D51D148AB800569A72 /* Brisk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Brisk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C28001D81D148AB800569A72 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -147,6 +173,8 @@
 			isa = PBXGroup;
 			children = (
 				C28001EC1D148AB800569A72 /* Info.plist */,
+				C27DBF251EF8F12D007666C3 /* openradar.json */,
+				C27694551EFD0BD4009C3FA1 /* openradarstrings.json */,
 				C2D0B2061DAB6D0E005E804F /* radar.json */,
 			);
 			path = Resources;
@@ -203,9 +231,13 @@
 		C28001E91D148AB800569A72 /* BriskTests */ = {
 			isa = PBXGroup;
 			children = (
+				C27DBF271EF8F6E2007666C3 /* DictionaryExtensionTests.swift */,
+				C27DBF211EF8F039007666C3 /* OpenRadarTests.swift */,
+				C23ED50B1EFA2DA9006988BA /* RadarIDParsingTests.swift */,
 				C2D0B2081DAB6D23005E804F /* RadarSerializationTests.swift */,
-				C255C4421DAB7A9C00383D0A /* ResultTests.swift */,
 				C255C4401DAB79C100383D0A /* Resources */,
+				C255C4421DAB7A9C00383D0A /* ResultTests.swift */,
+				C276944F1EFCD461009C3FA1 /* StringExtensionTests.swift */,
 			);
 			path = BriskTests;
 			sourceTree = "<group>";
@@ -222,14 +254,19 @@
 		C2839A1E1D14F59400D240C4 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				C27A5A161E721BD300391E63 /* Attachment+Serialization.swift */,
 				C2839A271D14FE8B00D240C4 /* Data+Extension.swift */,
+				C27DBF2A1EF8F75C007666C3 /* Dictionary+Extension.swift */,
+				C23ED5071EFA1FD1006988BA /* NSDocumentController+Extension.swift */,
 				C2839A1A1D14F2E100D240C4 /* NSPopUpButton+Extension.swift */,
+				C23ED5091EFA2362006988BA /* NSProgressIndicator+Extension.swift */,
 				C219CBD71D173602002F89FC /* NSStatusItem+Extension.swift */,
 				C20DDC151D1673670086D304 /* NSStoryboard+Extension.swift */,
 				C2839A181D14F2CF00D240C4 /* NSTextField+Extension.swift */,
 				C2839A161D14F2B100D240C4 /* NSTextView+Extension.swift */,
+				C27DBF231EF8F071007666C3 /* Radar+OpenRadar.swift */,
 				C2D0B20A1DAB6F00005E804F /* Radar+Serialization.swift */,
-				C27A5A161E721BD300391E63 /* Attachment+Serialization.swift */,
+				C27694531EFD097C009C3FA1 /* String+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -237,6 +274,7 @@
 		C2839A201D14F5A900D240C4 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				C27694511EFD094F009C3FA1 /* OpenRadar.swift */,
 				C20DDC191D167D5F0086D304 /* RadarDocument.swift */,
 				C2839A231D14FC7000D240C4 /* Result.swift */,
 				C2839A141D14F29B00D240C4 /* Validatable.swift */,
@@ -250,6 +288,7 @@
 				C2C360161D172A9A00217D22 /* AppleRadarPreferencesViewController.swift */,
 				C20DDC111D16496E0086D304 /* AuthenticationViewController.swift */,
 				C2E8AE971D168A9200A65DB0 /* CascadingWindowController.swift */,
+				C23ED5041EFA1174006988BA /* FileDuplicateViewController.swift */,
 				C2ED20571D172437002A54B0 /* OpenRadarPreferencesViewController.swift */,
 				C28399CB1D148CDC00D240C4 /* RadarViewController.swift */,
 				C2C360181D172DB400217D22 /* TabViewController.swift */,
@@ -404,6 +443,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C27694561EFD0BD4009C3FA1 /* openradarstrings.json in Resources */,
+				C27DBF261EF8F12D007666C3 /* openradar.json in Resources */,
 				C2D0B2071DAB6D0E005E804F /* radar.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -518,16 +559,20 @@
 				C219CBDA1D1736EB002F89FC /* Application.swift in Sources */,
 				C2ED20581D172437002A54B0 /* OpenRadarPreferencesViewController.swift in Sources */,
 				C2839A1B1D14F2E100D240C4 /* NSPopUpButton+Extension.swift in Sources */,
+				C27DBF241EF8F071007666C3 /* Radar+OpenRadar.swift in Sources */,
 				C219CBD81D173602002F89FC /* NSStatusItem+Extension.swift in Sources */,
 				C2042B531D17397900DEF594 /* ViewController.swift in Sources */,
 				C2E8AE981D168A9200A65DB0 /* CascadingWindowController.swift in Sources */,
 				C27F3B721D8B239B00EA3B7D /* Constants.swift in Sources */,
+				C23ED5081EFA1FD1006988BA /* NSDocumentController+Extension.swift in Sources */,
 				C20DDC161D1673670086D304 /* NSStoryboard+Extension.swift in Sources */,
 				C2839A281D14FE8B00D240C4 /* Data+Extension.swift in Sources */,
+				C23ED5061EFA14E1006988BA /* FileDuplicateViewController.swift in Sources */,
 				C2839A241D14FC7000D240C4 /* Result.swift in Sources */,
 				E8D9E1C51E98636300D392B7 /* GlobalHotKey.swift in Sources */,
 				C2C360191D172DB400217D22 /* TabViewController.swift in Sources */,
 				C20DDC141D1652C20086D304 /* Keychain.swift in Sources */,
+				C27694541EFD097C009C3FA1 /* String+Extension.swift in Sources */,
 				C28001D91D148AB800569A72 /* AppDelegate.swift in Sources */,
 				C2C042271EF6F781008BFC88 /* TextView.swift in Sources */,
 				C28399CC1D148CDC00D240C4 /* RadarViewController.swift in Sources */,
@@ -535,11 +580,14 @@
 				C20DDC181D16771A0086D304 /* StoryboardRouter.swift in Sources */,
 				C2839A151D14F29B00D240C4 /* Validatable.swift in Sources */,
 				C20DDC121D16496E0086D304 /* AuthenticationViewController.swift in Sources */,
+				C23ED50A1EFA2362006988BA /* NSProgressIndicator+Extension.swift in Sources */,
 				C27A5A171E721BD300391E63 /* Attachment+Serialization.swift in Sources */,
 				C2839A191D14F2CF00D240C4 /* NSTextField+Extension.swift in Sources */,
+				C27DBF2B1EF8F75C007666C3 /* Dictionary+Extension.swift in Sources */,
 				C2C360171D172A9A00217D22 /* AppleRadarPreferencesViewController.swift in Sources */,
 				C2839A171D14F2B100D240C4 /* NSTextView+Extension.swift in Sources */,
 				C20DDC1A1D167D5F0086D304 /* RadarDocument.swift in Sources */,
+				C27694521EFD094F009C3FA1 /* OpenRadar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -547,7 +595,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C27DBF221EF8F039007666C3 /* OpenRadarTests.swift in Sources */,
+				C27DBF281EF8F6E2007666C3 /* DictionaryExtensionTests.swift in Sources */,
+				C27694501EFCD461009C3FA1 /* StringExtensionTests.swift in Sources */,
 				C255C4431DAB7A9C00383D0A /* ResultTests.swift in Sources */,
+				C23ED50C1EFA2DA9006988BA /* RadarIDParsingTests.swift in Sources */,
 				C2D0B2091DAB6D23005E804F /* RadarSerializationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Brisk/AppDelegate.swift
+++ b/Brisk/AppDelegate.swift
@@ -30,13 +30,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_ sender: NSApplication, openFiles filenames: [String]) {
-        let documentController = NSDocumentController.shared()
-        let type = "com.brisk.radar"
-
         for filename in filenames {
             let url = URL(fileURLWithPath: filename)
-            if let document = try? documentController.makeDocument(withContentsOf: url, ofType: type) {
-                documentController.addDocument(document)
+            if let document = NSDocumentController.shared().makeRadarDocument(withContentsOf: url) {
+                NSDocumentController.shared().addDocument(document)
                 document.showWindows()
             }
         }

--- a/Brisk/Controllers/FileDuplicateViewController.swift
+++ b/Brisk/Controllers/FileDuplicateViewController.swift
@@ -1,0 +1,82 @@
+import Alamofire
+import AppKit
+import Sonar
+
+final class FileDuplicateViewController: ViewController {
+    @IBOutlet private var progressIndicator: NSProgressIndicator!
+    @IBOutlet private var radarIDTextField: NSTextField!
+    @IBOutlet private var searchButton: NSButton!
+
+    @IBAction private func searchForOpenRadar(_ sender: NSButton) {
+        let setLoading: (Bool) -> Void = { [weak self] loading in
+            self?.progressIndicator.isLoading = loading
+            self?.radarIDTextField.isEnabled = !loading
+            self?.searchButton.isEnabled = !loading
+        }
+
+        setLoading(true)
+        let id = radarID(from: self.radarIDTextField.stringValue)!
+        let url = URL(string: "https://openradar.appspot.com/api/radar?number=\(id)")!
+        Alamofire.request(url)
+            .validate()
+            .responseJSON { [weak self] result in
+                setLoading(false)
+
+                if let error = result.error {
+                    self?.show(NSAlert(error: error))
+                    return
+                }
+
+                guard let json = result.value as? [String: Any],
+                    let result = json["result"] as? [String: Any], !result.isEmpty else
+                {
+                    self?.showError(title: "No OpenRadar found",
+                                    message: "Couldn't find an OpenRadar with ID #\(id)")
+                    return
+                }
+
+                guard let radar = try? Radar(openRadar: json),
+                    let document = NSDocumentController.shared().makeRadarDocument() else
+                {
+                    self?.showError(title: "Invalid OpenRadar",
+                                    message: "OpenRadar is missing required fields")
+                    return
+                }
+
+                document.makeWindowControllers(for: radar)
+                NSDocumentController.shared().addDocument(document)
+                document.showWindows()
+
+                self?.view.window?.windowController?.close()
+            }
+    }
+
+    override func controlTextDidChange(_ notification: Notification) {
+        assert(notification.object as? NSTextField === self.radarIDTextField)
+        self.searchButton.isEnabled = radarID(from: self.radarIDTextField.stringValue) != nil
+    }
+
+    private func showError(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        self.show(alert)
+    }
+
+    private func show(_ alert: NSAlert) {
+        alert.runModal()
+        self.radarIDTextField.becomeFirstResponder()
+    }
+}
+
+public func radarID(from string: String) -> String? {
+    guard let text = string.components(separatedBy: "/").last?.strip(), !text.isEmpty else {
+        return nil
+    }
+
+    if text.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted)?.isEmpty != false {
+        return text
+    } else {
+        return nil
+    }
+}

--- a/Brisk/Extensions/Attachment+Serialization.swift
+++ b/Brisk/Extensions/Attachment+Serialization.swift
@@ -1,6 +1,6 @@
 import Sonar
 
-extension Attachment {
+public extension Attachment {
     func toJSON() -> [String: Any] {
         return [
             "filename": self.filename,
@@ -25,7 +25,7 @@ extension Attachment {
         self.init(filename: filename, mimeType: mimeType, data: data)
     }
 
-    init(filename: String, mimeType: String, data: Data) {
+    public init(filename: String, mimeType: String, data: Data) {
         self.filename = filename
         self.mimeType = mimeType
         self.data = data

--- a/Brisk/Extensions/Data+Extension.swift
+++ b/Brisk/Extensions/Data+Extension.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-extension Data {
-    func toJSONDictionary() -> [String: Any]? {
+public extension Data {
+    public func toJSONDictionary() -> [String: Any]? {
         return (try? JSONSerialization.jsonObject(with: self, options: [])) as? [String: Any]
     }
 }

--- a/Brisk/Extensions/Dictionary+Extension.swift
+++ b/Brisk/Extensions/Dictionary+Extension.swift
@@ -1,0 +1,21 @@
+public extension Dictionary where Key == String {
+    public func onlyStrings() -> [String: String] {
+        var newDictionary = [String: String]()
+        for (key, value) in self {
+            newDictionary[key] = value as? String
+        }
+
+        return newDictionary
+    }
+}
+
+public extension Dictionary where Key == String, Value == String {
+    public func filterEmpty() -> [String: String] {
+        var newDictionary = [String: String]()
+        for (key, value) in self where !value.isEmpty {
+            newDictionary[key] = value
+        }
+
+        return newDictionary
+    }
+}

--- a/Brisk/Extensions/NSDocumentController+Extension.swift
+++ b/Brisk/Extensions/NSDocumentController+Extension.swift
@@ -1,0 +1,13 @@
+import AppKit
+
+private let kDocumentType = "com.brisk.radar"
+
+extension NSDocumentController {
+    func makeRadarDocument() -> RadarDocument? {
+        return (try? self.makeUntitledDocument(ofType: kDocumentType)) as? RadarDocument
+    }
+
+    func makeRadarDocument(withContentsOf url: URL) -> RadarDocument? {
+        return (try? self.makeDocument(withContentsOf: url, ofType: kDocumentType)) as? RadarDocument
+    }
+}

--- a/Brisk/Extensions/NSProgressIndicator+Extension.swift
+++ b/Brisk/Extensions/NSProgressIndicator+Extension.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+extension NSProgressIndicator {
+    var isLoading: Bool {
+        set(loading) {
+            if loading {
+                self.startAnimation(nil)
+            } else {
+                self.stopAnimation(nil)
+            }
+        }
+
+        get {
+            assertionFailure("This value is bogus")
+            return false
+        }
+    }
+}

--- a/Brisk/Extensions/Radar+OpenRadar.swift
+++ b/Brisk/Extensions/Radar+OpenRadar.swift
@@ -1,0 +1,67 @@
+import Sonar
+
+public enum OpenRadarParsingError: Error {
+    case noResult
+    case missingRequiredFields
+    case invalidFormat
+}
+
+public extension Radar {
+    public init(openRadar json: [String: Any]) throws {
+        guard let dictionary = json["result"] as? [String: Any] else {
+            throw OpenRadarParsingError.noResult
+        }
+
+        let json = dictionary.onlyStrings().filterEmpty()
+        guard let title = json["title"], let description = json["description"] else {
+            throw OpenRadarParsingError.missingRequiredFields
+        }
+
+        let classificationString = json["classification"]?.lowercased()
+        let classification = Classification.All.first { $0.name.lowercased() == classificationString }
+            ?? Classification.All.first!
+        let productString = json["product"]?.lowercased()
+        let product = Product.All.first { $0.name.lowercased() == productString } ?? Product.All.first!
+
+        let reproducibilityString = json["reproducible"]?.lowercased()
+        let reproducibility = Reproducibility.All.first { $0.name.lowercased() == reproducibilityString }
+            ?? Reproducibility.All.first!
+
+        // Pick the last area (if there are any for the product) instead of defaulting to the first one from
+        // the UI. Ideally we just wouldn't pick one in this case
+        let lastArea = Area.areas(for: product).last
+
+        let productVersion = json["product_version"]
+        let radarID = json["number"]
+
+        do {
+            let openRadar = try description.openRadarFromSummary()
+            let version = productVersion ?? openRadar.version ?? " "
+            let updatedDescription = summary(for: radarID, description: openRadar.description ?? description)
+            let area = Area.areas(for: product)
+                .first { $0.name.lowercased() == openRadar.areaString?.lowercased() }
+
+            self.init(classification: classification, product: product, reproducibility: reproducibility,
+                      title: title, description: updatedDescription, steps: openRadar.steps ?? " ",
+                      expected: openRadar.expected ?? " ", actual: openRadar.actual ?? " ",
+                      configuration: openRadar.configuration ?? version, version: version,
+                      notes: openRadar.notes ?? " ", attachments: [], area: area ?? lastArea)
+
+        } catch is OpenRadarParsingError {
+            let updatedDescription = summary(for: radarID, description: description)
+            let version = productVersion ?? " "
+
+            self.init(classification: classification, product: product, reproducibility: reproducibility,
+                      title: title, description: updatedDescription, steps: " ", expected: " ", actual: " ",
+                      configuration: version, version: version, notes: " ", attachments: [], area: lastArea)
+
+        } catch let error {
+            assertionFailure("Got unexpected error type \(error)")
+            throw error
+        }
+    }
+}
+
+private func summary(for radarID: String?, description: String) -> String {
+    return radarID.map { "This is a duplicate of radar #\($0)\n\n\(description)\n" } ?? description
+}

--- a/Brisk/Extensions/Radar+Serialization.swift
+++ b/Brisk/Extensions/Radar+Serialization.swift
@@ -1,6 +1,6 @@
 import Sonar
 
-extension Radar {
+public extension Radar {
     func toData() throws -> Data {
         var JSON: [String: Any] = [
             "title": self.title,
@@ -24,7 +24,7 @@ extension Radar {
         return try JSONSerialization.data(withJSONObject: JSON, options: [])
     }
 
-    init?(json: [String: Any]) {
+    public init?(json: [String: Any]) {
         guard let title = json["title"] as? String,
             let description = json["description"] as? String,
             let classificationID = json["classification_id"] as? Int,

--- a/Brisk/Extensions/String+Extension.swift
+++ b/Brisk/Extensions/String+Extension.swift
@@ -1,0 +1,13 @@
+public extension String {
+    public func strip() -> String {
+        return self.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+public func appendOrReturn(_ string1: String?, _ string2: String?) -> String? {
+    if let string1 = string1, let string2 = string2 {
+        return string1 + "\n" + string2
+    }
+
+    return string1 ?? string2
+}

--- a/Brisk/Models/OpenRadar.swift
+++ b/Brisk/Models/OpenRadar.swift
@@ -1,0 +1,63 @@
+private let sectionToSetter: [String: (inout OpenRadar, String) -> Void] = [
+    "actual results": { $0.actual = appendOrReturn($0.actual, $1) },
+    "area": { $0.areaString = $1 },
+    "configuration": { $0.configuration = $1 },
+    "expected results": { $0.expected = $1 },
+    "notes": { $0.notes = $1 },
+    "observed results": { $0.actual = appendOrReturn($0.actual, $1) },
+    "steps to reproduce": { $0.steps = $1 },
+    "summary": { $0.description = $1 },
+    "version": { $0.version = $1 },
+]
+
+#if swift(>=4.0)
+Change this to use keypaths instead
+#endif
+public struct OpenRadar {
+    public var actual: String?
+    public var areaString: String?
+    public var configuration: String?
+    public var description: String?
+    public var expected: String?
+    public var notes: String?
+    public var steps: String?
+    public var version: String?
+
+    fileprivate init() {}
+}
+
+public extension String {
+    public func openRadarFromSummary() throws -> OpenRadar {
+        let components = self.components(separatedBy: "\r\n")
+        var openRadar = OpenRadar()
+        var parts = [String]()
+        var lastSetter: ((inout OpenRadar, String) -> Void)?
+
+        for component in components {
+            guard component.characters.last == ":",
+                let setter = sectionToSetter[String(component.characters.dropLast()).lowercased()] else
+            {
+                parts.append(component)
+                continue
+            }
+
+            if !parts.isEmpty && lastSetter == nil {
+                throw OpenRadarParsingError.invalidFormat
+            }
+
+            lastSetter?(&openRadar, parts.joined(separator: "\r\n").strip())
+            parts = []
+            lastSetter = setter
+        }
+
+        if let setter = lastSetter {
+            if !parts.isEmpty {
+                setter(&openRadar, parts.joined(separator: "\r\n").strip())
+            }
+        } else {
+            throw OpenRadarParsingError.invalidFormat
+        }
+
+        return openRadar
+    }
+}

--- a/Brisk/Models/RadarDocument.swift
+++ b/Brisk/Models/RadarDocument.swift
@@ -5,7 +5,7 @@ private struct DocumentError: Error {}
 
 final class RadarDocument: NSDocument {
     override func makeWindowControllers() {
-        self.createWindowController(radar: nil)
+        self.makeWindowControllers(for: nil)
     }
 
     override func data(ofType typeName: String) throws -> Data {
@@ -19,13 +19,13 @@ final class RadarDocument: NSDocument {
 
     override func read(from data: Data, ofType typeName: String) throws {
         if let json = data.toJSONDictionary(), let radar = Radar(json: json) {
-            self.createWindowController(radar: radar)
+            self.makeWindowControllers(for: radar)
         } else {
             throw DocumentError()
         }
     }
 
-    private func createWindowController(radar: Radar?) {
+    func makeWindowControllers(for radar: Radar?) {
         let windowController = NSStoryboard.main.instantiateWindowController(identifier: "Radar")
         if let radar = radar {
             let viewController = windowController.contentViewController as! RadarViewController

--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -70,6 +70,11 @@
                                                 <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Duplicate Radar" keyEquivalent="N" id="ei8-CZ-Vn9">
+                                            <connections>
+                                                <segue destination="D64-kD-tcp" kind="show" id="whm-ym-k0Q"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                             <connections>
                                                 <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
@@ -662,6 +667,11 @@
                                 <action selector="newDocument:" target="Ady-hI-5gd" id="tGo-Dd-NyP"/>
                             </connections>
                         </menuItem>
+                        <menuItem title="Duplicate Radar" keyEquivalent="N" id="7bU-cP-0CW">
+                            <connections>
+                                <segue destination="D64-kD-tcp" kind="show" id="NMT-lH-mGs"/>
+                            </connections>
+                        </menuItem>
                         <menuItem isSeparatorItem="YES" id="C9k-Lz-Ugo"/>
                         <menuItem title="About Brisk" id="pxB-gx-pau">
                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -687,6 +697,11 @@
                         <menuItem title="New Radar" keyEquivalent="n" id="crX-en-X1E">
                             <connections>
                                 <action selector="newDocument:" target="Ady-hI-5gd" id="OCq-y4-VD9"/>
+                            </connections>
+                        </menuItem>
+                        <menuItem title="Duplicate Radar" keyEquivalent="N" id="flG-Vy-mbB">
+                            <connections>
+                                <segue destination="D64-kD-tcp" kind="show" id="y0R-3a-mT6"/>
                             </connections>
                         </menuItem>
                         <menuItem isSeparatorItem="YES" id="VV1-qI-Dps"/>
@@ -831,7 +846,7 @@ DQ
                 </viewController>
                 <customObject id="Vzg-3m-G7u" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="817.5" y="534.5"/>
+            <point key="canvasLocation" x="818" y="535"/>
         </scene>
         <!--Window Controller-->
         <scene sceneID="PjS-oh-kSn">
@@ -1490,12 +1505,97 @@ DQ
             </objects>
             <point key="canvasLocation" x="74.5" y="946.5"/>
         </scene>
+        <!--Window Controller-->
+        <scene sceneID="2Dq-t1-K7p">
+            <objects>
+                <customObject id="CQg-FY-SsY" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <windowController storyboardIdentifier="Duplicate" showSeguePresentationStyle="single" id="D64-kD-tcp" sceneMemberID="viewController">
+                    <window key="window" title="Duplicate Radar" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="Bsl-hp-bzl">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <rect key="contentRect" x="195" y="240" width="300" height="111"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1440" height="878"/>
+                    </window>
+                    <connections>
+                        <segue destination="Xni-wx-69z" kind="relationship" relationship="window.shadowedContentViewController" id="f7D-zp-r9L"/>
+                    </connections>
+                </windowController>
+            </objects>
+            <point key="canvasLocation" x="1177" y="266"/>
+        </scene>
+        <!--File Duplicate View Controller-->
+        <scene sceneID="J0Z-qc-GNk">
+            <objects>
+                <customObject id="bD7-G1-deH" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <viewController id="Xni-wx-69z" customClass="FileDuplicateViewController" customModule="Brisk" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="j8R-xG-DDr">
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="91"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfU-h5-WcA">
+                                <rect key="frame" x="84" y="49" width="196" height="22"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="6pe-UU-vnv">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="Xni-wx-69z" id="Bcg-WF-ATB"/>
+                                </connections>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vLe-VI-Kfh">
+                                <rect key="frame" x="18" y="52" width="60" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Radar ID:" id="aMo-Ie-IPB">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="k2R-To-ztj">
+                                <rect key="frame" x="203" y="13" width="83" height="32"/>
+                                <buttonCell key="cell" type="push" title="Search" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="IMQ-JU-197">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                    <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="searchForOpenRadar:" target="Xni-wx-69z" id="cWF-eu-uIA"/>
+                                </connections>
+                            </button>
+                            <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="xEZ-9q-9Dh">
+                                <rect key="frame" x="185" y="23" width="16" height="16"/>
+                            </progressIndicator>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="vLe-VI-Kfh" firstAttribute="baseline" secondItem="cfU-h5-WcA" secondAttribute="baseline" id="1AM-Cg-fnc"/>
+                            <constraint firstItem="k2R-To-ztj" firstAttribute="leading" secondItem="xEZ-9q-9Dh" secondAttribute="trailing" constant="8" id="6PQ-nS-OqS"/>
+                            <constraint firstItem="vLe-VI-Kfh" firstAttribute="leading" secondItem="j8R-xG-DDr" secondAttribute="leading" constant="20" id="ECf-bl-N9U"/>
+                            <constraint firstItem="cfU-h5-WcA" firstAttribute="top" secondItem="j8R-xG-DDr" secondAttribute="top" constant="20" id="Ilw-S5-nx3"/>
+                            <constraint firstAttribute="bottom" secondItem="k2R-To-ztj" secondAttribute="bottom" constant="20" id="KAD-qP-Eej"/>
+                            <constraint firstItem="cfU-h5-WcA" firstAttribute="leading" secondItem="vLe-VI-Kfh" secondAttribute="trailing" constant="8" id="KM1-oR-asm"/>
+                            <constraint firstItem="k2R-To-ztj" firstAttribute="trailing" secondItem="cfU-h5-WcA" secondAttribute="trailing" id="Rtj-sn-ueq"/>
+                            <constraint firstItem="xEZ-9q-9Dh" firstAttribute="centerY" secondItem="k2R-To-ztj" secondAttribute="centerY" id="Sbz-tf-29o"/>
+                            <constraint firstAttribute="trailing" secondItem="cfU-h5-WcA" secondAttribute="trailing" constant="20" id="bC3-Hj-QMf"/>
+                            <constraint firstItem="k2R-To-ztj" firstAttribute="top" secondItem="cfU-h5-WcA" secondAttribute="bottom" constant="8" id="kTP-ct-Z23"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="progressIndicator" destination="xEZ-9q-9Dh" id="hYx-xn-C3a"/>
+                        <outlet property="radarIDTextField" destination="cfU-h5-WcA" id="1pj-RB-6cW"/>
+                        <outlet property="searchButton" destination="k2R-To-ztj" id="dwj-gP-4L7"/>
+                    </connections>
+                </viewController>
+            </objects>
+            <point key="canvasLocation" x="1177" y="519"/>
+        </scene>
     </scenes>
     <resources>
         <image name="NSPreferencesGeneral" width="32" height="32"/>
-        <image name="radar" width="180" height="180"/>
+        <image name="radar" width="64" height="64"/>
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="XTz-8q-MhS"/>
+        <segue reference="y0R-3a-mT6"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/BriskTests/DictionaryExtensionTests.swift
+++ b/BriskTests/DictionaryExtensionTests.swift
@@ -1,0 +1,20 @@
+import Brisk
+import XCTest
+
+final class DictionaryExtensionTests: XCTestCase {
+    func testFilteringExceptStrings() {
+        let dictionary: [String: Any] = ["foo": "bar", "baz": 1]
+        let newDictionary = dictionary.onlyStrings()
+
+        XCTAssertEqual(newDictionary.count, 1)
+        XCTAssertEqual(newDictionary["foo"], "bar")
+    }
+
+    func testFilteringEmptyStrings() {
+        let dictionary: [String: String] = ["foo": "", "bar": "baz"]
+        let newDictionary = dictionary.filterEmpty()
+
+        XCTAssertEqual(newDictionary.count, 1)
+        XCTAssertEqual(newDictionary["bar"], "baz")
+    }
+}

--- a/BriskTests/OpenRadarTests.swift
+++ b/BriskTests/OpenRadarTests.swift
@@ -1,0 +1,129 @@
+import Brisk
+import Sonar
+import XCTest
+
+final class OpenRadarTests: XCTestCase {
+    func testDeserializingJSON() {
+        let json = loadOpenRadarJSON()
+        guard let radar = try? Radar(openRadar: json) else {
+            return XCTFail("Failed to deserializing open radar JSON")
+        }
+
+        XCTAssertEqual(radar.classification, .OtherBug)
+        XCTAssertEqual(radar.product, .DeveloperTools)
+        XCTAssertEqual(radar.reproducibility, .Always)
+        XCTAssertEqual(radar.version, "Xcode 9.0")
+        XCTAssertEqual(radar.configuration, "Xcode 9.0")
+        XCTAssertEqual(radar.title, "Some title")
+        XCTAssertEqual(radar.description, "This is a duplicate of radar #1234\n\nfoo\n\nbar\nbaz\n")
+        XCTAssertEqual(radar.steps, "1. foo\n2. bar")
+        XCTAssertEqual(radar.expected, "foo")
+        XCTAssertEqual(radar.actual, "bar")
+        XCTAssertEqual(radar.version, "Xcode 9.0")
+        XCTAssertEqual(radar.notes, "some notes")
+    }
+
+    func testOpenRadarMissingResult() {
+        do {
+            _ = try Radar(openRadar: [:])
+            XCTFail("Radar shouldn't be valid")
+        } catch let error as OpenRadarParsingError {
+            XCTAssertEqual(error, .noResult)
+        } catch {
+            XCTFail("Got invalid error")
+        }
+    }
+
+    func testOpenRadarMissingTitle() {
+        do {
+            _ = try Radar(openRadar: ["result": [:]])
+            XCTFail("Radar shouldn't be valid")
+        } catch let error as OpenRadarParsingError {
+            XCTAssertEqual(error, .missingRequiredFields)
+        } catch {
+            XCTFail("Got invalid error")
+        }
+    }
+
+    func testObservedAndActualAppend() {
+        let string = "Observed results:\r\nfoo\r\nActual Results:\r\nbar"
+        guard let openRadar = try? string.openRadarFromSummary() else {
+            return XCTFail("Failed to parse valid description")
+        }
+
+        XCTAssertEqual(openRadar.actual, "foo\nbar")
+    }
+
+    func testParsingOpenRadar() {
+        guard let openRadar = try? loadOpenRadarString(.regular).openRadarFromSummary() else {
+            return XCTFail("Failed to parse valid description")
+        }
+
+        XCTAssertEqual(openRadar.description, "foo\n\nbar\nbaz")
+        XCTAssertEqual(openRadar.steps, "1. foo\n2. bar")
+        XCTAssertEqual(openRadar.expected, "foo")
+        XCTAssertEqual(openRadar.actual, "bar")
+        XCTAssertEqual(openRadar.version, "Xcode 9.0")
+        XCTAssertEqual(openRadar.notes, "some notes")
+        XCTAssertEqual(openRadar.configuration, "some config")
+    }
+
+    func testParsingArea() {
+        guard let openRadar = try? "Area:\r\nfoo".openRadarFromSummary() else {
+            return XCTFail("Failed to parse valid description")
+        }
+
+        XCTAssertEqual(openRadar.areaString, "foo")
+    }
+
+    func testParsingLongerOpenRadar() {
+        guard let openRadar = try? loadOpenRadarString(.long).openRadarFromSummary() else {
+            return XCTFail("Failed to parse valid radar")
+        }
+
+        XCTAssertEqual(openRadar.description, "foo\n\nbar\nbaz\n\nqux\n\nfoo\nbar\n\nbaz\n\nqux")
+        XCTAssertEqual(openRadar.steps, "foo")
+        XCTAssertEqual(openRadar.expected, "bar")
+        XCTAssertEqual(openRadar.actual, "baz")
+        XCTAssertEqual(openRadar.version, "foo")
+        XCTAssertNil(openRadar.notes)
+    }
+
+    func testParsingPartiallyValidRadar() {
+        do {
+            _ = try "foo.\r\n\r\nSummary:\r\nbar\r\nbaz".openRadarFromSummary()
+            XCTFail("Open radar should be invalid")
+        } catch let error as OpenRadarParsingError {
+            XCTAssertEqual(error, .invalidFormat)
+        } catch let error {
+            XCTFail("Invalid error thrown: \(error)")
+        }
+    }
+
+    func testParsingUnformattedOpenRadar() {
+        do {
+            _ = try "foo.\r\n\r\nbar\r\nbaz".openRadarFromSummary()
+            XCTFail("Open radar should be invalid")
+        } catch let error as OpenRadarParsingError {
+            XCTAssertEqual(error, .invalidFormat)
+        } catch let error {
+            XCTFail("Invalid error thrown: \(error)")
+        }
+    }
+
+}
+
+private enum StringID: String {
+    case regular
+    case long
+}
+
+private func loadOpenRadarString(_ stringID: StringID) -> String {
+    let url = Bundle(for: OpenRadarTests.self).url(forResource: "openradarstrings", withExtension: "json")!
+    return try! Data(contentsOf: url).toJSONDictionary()!.onlyStrings()[stringID.rawValue]!
+}
+
+private func loadOpenRadarJSON() -> [String: Any] {
+    let url = Bundle(for: OpenRadarTests.self).url(forResource: "openradar", withExtension: "json")!
+    return try! Data(contentsOf: url).toJSONDictionary()!
+}

--- a/BriskTests/RadarIDParsingTests.swift
+++ b/BriskTests/RadarIDParsingTests.swift
@@ -1,0 +1,20 @@
+import Brisk
+import XCTest
+
+final class RadarIDParsingTests: XCTestCase {
+    func testParsingNormalRadarID() {
+        XCTAssertEqual(radarID(from: "1234"), "1234")
+    }
+
+    func testParsingRadarString() {
+        XCTAssertNil(radarID(from: "foobar"))
+    }
+
+    func testParsingRadarURL() {
+        XCTAssertEqual(radarID(from: "rdar://1234"), "1234")
+    }
+
+    func testParsingProblemURL() {
+        XCTAssertEqual(radarID(from: "rdar://problem/1234"), "1234")
+    }
+}

--- a/BriskTests/RadarSerializationTests.swift
+++ b/BriskTests/RadarSerializationTests.swift
@@ -1,4 +1,4 @@
-@testable import Brisk
+import Brisk
 import Sonar
 import XCTest
 

--- a/BriskTests/Resources/openradar.json
+++ b/BriskTests/Resources/openradar.json
@@ -1,0 +1,16 @@
+{
+    "result": {
+        "classification": "Other Bug",
+        "description": "Summary:\r\nfoo\n\nbar\nbaz\n\r\n\r\nSteps to Reproduce:\r\n1. foo\n2. bar\n\r\n\r\nExpected Results:\r\nfoo\n\r\n\r\nActual Results:\r\nbar\n\r\n\r\nVersion:\r\nXcode 9.0\r\n\r\nNotes:\r\n\r\nsome notes\n",
+        "id": 123456,
+        "number": "1234",
+        "originated": "19-Jun-2017 21:22",
+        "product": "Developer Tools",
+        "product_version": "Xcode 9.0",
+        "reproducible": "Always",
+        "resolved": "",
+        "status": "Open",
+        "title": "Some title",
+        "user": "foo@bar.com"
+    }
+}

--- a/BriskTests/Resources/openradarstrings.json
+++ b/BriskTests/Resources/openradarstrings.json
@@ -1,0 +1,4 @@
+{
+    "regular": "Summary:\r\nfoo\n\nbar\nbaz\n\r\n\r\nSteps to Reproduce:\r\n1. foo\n2. bar\n\r\n\r\nExpected Results:\r\nfoo\n\r\n\r\nActual Results:\r\nbar\n\r\n\r\nVersion:\r\nXcode 9.0\r\n\r\nNotes:\r\n\r\nsome notes\r\nConfiguration:\r\nsome config",
+    "long": "Summary:\r\nfoo\n\nbar\nbaz\n\nqux\n\nfoo\nbar\n\nbaz\n\nqux\r\n\r\nSteps to Reproduce:\r\nfoo\r\n\r\nExpected Results:\r\nbar\r\n\r\nActual Results:\r\nbaz\r\n\r\nVersion:\r\nfoo\r\n\r\nNotes:"
+}

--- a/BriskTests/StringExtensionTests.swift
+++ b/BriskTests/StringExtensionTests.swift
@@ -1,0 +1,20 @@
+import Brisk
+import XCTest
+
+final class StringExtensionTests: XCTestCase {
+    func testAppendOrReturnBothExist() {
+        XCTAssertEqual(appendOrReturn("foo", "bar"), "foo\nbar")
+    }
+
+    func testAppendOrReturnBothNil() {
+        XCTAssertEqual(appendOrReturn(nil, nil), nil)
+    }
+
+    func testAppendOrReturnFirstString() {
+        XCTAssertEqual(appendOrReturn("foo", nil), "foo")
+    }
+
+    func testAppendOrReturnSecondString() {
+        XCTAssertEqual(appendOrReturn(nil, "bar"), "bar")
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   [issue](https://github.com/br1sk/brisk/issues/52)
   [change](https://github.com/br1sk/brisk/pull/78)
 
+- Add UI for duping radars from OpenRadar
+  [issue](https://github.com/br1sk/brisk/issues/14)
+  [change](https://github.com/br1sk/brisk/pull/75)
+
 ## Bug Fixes
 
 - Typing emoji caused font to change

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,7 +12,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Sonar:
-    :commit: 97607c59a704f7642d23a2150f512d481d18150b
+    :commit: 48b65e9b95bbcee1b36affc34dd878b276499187
     :git: https://github.com/br1sk/Sonar.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
This adds a new window for duping a radar. It takes the ID of a radar,
searches OpenRadar for the details about it, and then fills the normal
UI with the values from it.

The complex part of this is what we put into what fields in the UI from
OpenRadar. The OpenRadar API just returns one big blog of summary data
(exactly how radarweb displays it), so instead of parsing that, we're
just filling the description with that.

It ends up looking a little weird since we're only filling 1 of the 5
text views, but it shouldn't be a big deal. Also OpenRadar doesn't vend
the `area` field sent to radar, so to default to something we just
choose "other".