### PR TITLE
Make TextView tab and backtab switch between fields

### DIFF
--- a/Brisk/Views/TextView.swift
+++ b/Brisk/Views/TextView.swift
@@ -6,4 +6,19 @@ final class TextView: NSTextView {
 
         self.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize())
     }
+
+    override func doCommand(by selector: Selector) {
+        switch selector {
+        case #selector(TextView.insertTab(_:)):
+            self.window?.selectNextKeyView(self)
+        case #selector(TextView.insertBacktab(_:)):
+            self.window?.selectPreviousKeyView(self)
+        case #selector(NSWindow.selectNextKeyView(_:)):
+            super.doCommand(by: #selector(TextView.insertTab(_:)))
+        case #selector(NSWindow.selectPreviousKeyView(_:)):
+            super.doCommand(by: #selector(TextView.insertBacktab(_:)))
+        default:
+            super.doCommand(by: selector)
+        }
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # master
 
-## Breaking
-
-- None
-
 ## Enhancements
 
-- None
+- Make tab in text views jump between fields
+  [issue](https://github.com/br1sk/brisk/issues/52)
+  [change](https://github.com/br1sk/brisk/pull/78)
 
 ## Bug Fixes
 


### PR DESCRIPTION
Previously this would insert tabs into the textview, but this probably
makes more sense to navigate between fields. This flips the behavior of
Ctrl + tab switching between fields to make that actually insert a tab.