### PR TITLE
Follow rdar:// URLs

### DIFF
--- a/Brisk/Controllers/FileDuplicateViewController.swift
+++ b/Brisk/Controllers/FileDuplicateViewController.swift
@@ -7,6 +7,11 @@ final class FileDuplicateViewController: ViewController {
     @IBOutlet private var radarIDTextField: NSTextField!
     @IBOutlet private var searchButton: NSButton!
 
+    func searchForOpenRadar(text: String) {
+        self.radarIDTextField.stringValue = text
+        self.searchForOpenRadar(self.searchButton)
+    }
+
     @IBAction private func searchForOpenRadar(_ sender: NSButton) {
         let setLoading: (Bool) -> Void = { [weak self] loading in
             self?.progressIndicator.isLoading = loading

--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -656,6 +656,7 @@
                 </application>
                 <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Brisk" customModuleProvider="target">
                     <connections>
+                        <outlet property="dupeRadarMenuItem" destination="ei8-CZ-Vn9" id="5IR-Uw-JHd"/>
                         <outlet property="statusMenu" destination="ELE-Es-Vzl" id="OoV-hJ-uLb"/>
                     </connections>
                 </customObject>

--- a/Brisk/Resources/Info.plist
+++ b/Brisk/Resources/Info.plist
@@ -39,6 +39,17 @@
 	<string>0.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>BRSK</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string></string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>rdar</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   [issue](https://github.com/br1sk/brisk/issues/14)
   [change](https://github.com/br1sk/brisk/pull/75)
 
+- Respond to rdar:// URLs
+  [issue](https://github.com/br1sk/brisk/issues/77)
+  [change](https://github.com/br1sk/brisk/pull/79)
+
 ## Bug Fixes
 
 - Typing emoji caused font to change


### PR DESCRIPTION
This makes the app responsive to rdar:// URLs. rdar://12345 will open
the app, search OpenRadar for radar 12345, and will display its
contents if available on OpenRadar. The radar can then easily be duped.

Fixes https://github.com/br1sk/brisk/issues/77