### PR TITLE
Focus already open document on reopen

### DIFF
--- a/Brisk/AppDelegate.swift
+++ b/Brisk/AppDelegate.swift
@@ -35,7 +35,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func application(_ sender: NSApplication, openFiles filenames: [String]) {
         for filename in filenames {
             let url = URL(fileURLWithPath: filename)
-            if let document = NSDocumentController.shared().makeRadarDocument(withContentsOf: url) {
+
+            if let openDocument = NSDocumentController.shared().document(for: url) {
+                openDocument.showWindows()
+            } else if let document = NSDocumentController.shared().makeRadarDocument(withContentsOf: url) {
                 NSDocumentController.shared().addDocument(document)
                 document.showWindows()
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,7 @@
 
 - Use Radar icon in Preferences
   [change](https://github.com/br1sk/brisk/pull/74)
+
+- Focus existing windows when reopening documents
+  [issue](https://github.com/br1sk/brisk/issues/48)
+  [change](https://github.com/br1sk/brisk/issues/80)


### PR DESCRIPTION
Previously you could open a `.brisk` file multiple times. Now if that
file is already open, we focus the window(s) instead.