### PR TITLE
Use single user icon for open radar preferences

### DIFF
--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16E195" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
     </dependencies>
@@ -872,9 +872,9 @@ DQ
             <objects>
                 <tabViewController showSeguePresentationStyle="single" tabStyle="toolbar" id="BhG-02-uGX" customClass="TabViewController" customModule="Brisk" customModuleProvider="target" sceneMemberID="viewController">
                     <tabViewItems>
-                        <tabViewItem image="NSPreferencesGeneral" id="7Lx-JD-9GH"/>
-                        <tabViewItem image="radar" id="EDE-TC-H6U"/>
-                        <tabViewItem id="Mzz-Pe-pef"/>
+                        <tabViewItem label="General" image="NSPreferencesGeneral" id="7Lx-JD-9GH"/>
+                        <tabViewItem label="Apple Radar" image="radar" id="EDE-TC-H6U"/>
+                        <tabViewItem label="Open Radar" image="NSUser" id="Mzz-Pe-pef"/>
                     </tabViewItems>
                     <viewControllerTransitionOptions key="transitionOptions" allowUserInteraction="YES"/>
                     <tabView key="tabView" type="noTabsNoBorder" id="EE6-pS-Eyp">
@@ -1593,6 +1593,7 @@ DQ
     </scenes>
     <resources>
         <image name="NSPreferencesGeneral" width="32" height="32"/>
+        <image name="NSUser" width="32" height="32"/>
         <image name="radar" width="64" height="64"/>
     </resources>
     <inferredMetricsTieBreakers>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [issue](https://github.com/br1sk/brisk/issues/47)
   [change](https://github.com/br1sk/brisk/pull/83)
 
+- Use User icon for Open Radar preferences
+  [issue](https://github.com/br1sk/brisk/issues/15)
+  [change](https://github.com/br1sk/brisk/pull/84)
+
 ## Bug Fixes
 
 - Typing emoji caused font to change


### PR DESCRIPTION
For now this can be used as the last icon for preferences. In the future
I think we should change to a more Mail.app like approach where we have
a single accounts tab that has Apple Radar, Open Radar, and maybe things
like the Swift JIRA and Twitter. In that case we'll only have a single
icon.