### PR TITLE
Make configuration and notes fields optional

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,3 +28,13 @@ trailing_comma:
   mandatory_comma: true
 private_outlet:
   allow_private_set: true
+attributes:
+  always_on_line_above:
+    - "@discardableResult"
+    - "@IBDesignable"
+    - "@nonobjc"
+    - "@objc"
+  always_on_same_line:
+    - "@IBAction"
+    - "@IBInspectable"
+    - "@IBOutlet"

--- a/Brisk.xcodeproj/project.pbxproj
+++ b/Brisk.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C20DDC1A1D167D5F0086D304 /* RadarDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20DDC191D167D5F0086D304 /* RadarDocument.swift */; };
 		C219CBD81D173602002F89FC /* NSStatusItem+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219CBD71D173602002F89FC /* NSStatusItem+Extension.swift */; };
 		C219CBDA1D1736EB002F89FC /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = C219CBD91D1736EB002F89FC /* Application.swift */; };
+		C21DAA151EFF0D290016E8AA /* PlaceholderTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21DAA141EFF0D290016E8AA /* PlaceholderTextView.swift */; };
 		C23ED5061EFA14E1006988BA /* FileDuplicateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED5041EFA1174006988BA /* FileDuplicateViewController.swift */; };
 		C23ED5081EFA1FD1006988BA /* NSDocumentController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED5071EFA1FD1006988BA /* NSDocumentController+Extension.swift */; };
 		C23ED50A1EFA2362006988BA /* NSProgressIndicator+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23ED5091EFA2362006988BA /* NSProgressIndicator+Extension.swift */; };
@@ -85,6 +86,7 @@
 		C20DDC191D167D5F0086D304 /* RadarDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RadarDocument.swift; sourceTree = "<group>"; };
 		C219CBD71D173602002F89FC /* NSStatusItem+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSStatusItem+Extension.swift"; sourceTree = "<group>"; };
 		C219CBD91D1736EB002F89FC /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
+		C21DAA141EFF0D290016E8AA /* PlaceholderTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceholderTextView.swift; sourceTree = "<group>"; };
 		C23ED5041EFA1174006988BA /* FileDuplicateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileDuplicateViewController.swift; sourceTree = "<group>"; };
 		C23ED5071EFA1FD1006988BA /* NSDocumentController+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDocumentController+Extension.swift"; sourceTree = "<group>"; };
 		C23ED5091EFA2362006988BA /* NSProgressIndicator+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSProgressIndicator+Extension.swift"; sourceTree = "<group>"; };
@@ -310,6 +312,7 @@
 		C2C042251EF6F781008BFC88 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				C21DAA141EFF0D290016E8AA /* PlaceholderTextView.swift */,
 				C2C042261EF6F781008BFC88 /* TextView.swift */,
 			);
 			path = Views;
@@ -565,6 +568,7 @@
 				C2E8AE981D168A9200A65DB0 /* CascadingWindowController.swift in Sources */,
 				C27F3B721D8B239B00EA3B7D /* Constants.swift in Sources */,
 				C23ED5081EFA1FD1006988BA /* NSDocumentController+Extension.swift in Sources */,
+				C21DAA151EFF0D290016E8AA /* PlaceholderTextView.swift in Sources */,
 				C20DDC161D1673670086D304 /* NSStoryboard+Extension.swift in Sources */,
 				C2839A281D14FE8B00D240C4 /* Data+Extension.swift in Sources */,
 				C23ED5061EFA14E1006988BA /* FileDuplicateViewController.swift in Sources */,

--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -35,10 +35,8 @@ final class RadarViewController: ViewController {
         return [
             self.actualTextView,
             self.classificationPopUp,
-            self.configurationTextField,
             self.descriptionTextView,
             self.expectedTextView,
-            self.notesTextView,
             self.productPopUp,
             self.reproducibilityPopUp,
             self.stepsTextView,

--- a/Brisk/Extensions/Radar+OpenRadar.swift
+++ b/Brisk/Extensions/Radar+OpenRadar.swift
@@ -44,8 +44,8 @@ public extension Radar {
             self.init(classification: classification, product: product, reproducibility: reproducibility,
                       title: title, description: updatedDescription, steps: openRadar.steps ?? " ",
                       expected: openRadar.expected ?? " ", actual: openRadar.actual ?? " ",
-                      configuration: openRadar.configuration ?? version, version: version,
-                      notes: openRadar.notes ?? " ", attachments: [], area: area ?? lastArea)
+                      configuration: openRadar.configuration ?? "", version: version,
+                      notes: openRadar.notes ?? "", attachments: [], area: area ?? lastArea)
 
         } catch is OpenRadarParsingError {
             let updatedDescription = summary(for: radarID, description: description)
@@ -53,7 +53,7 @@ public extension Radar {
 
             self.init(classification: classification, product: product, reproducibility: reproducibility,
                       title: title, description: updatedDescription, steps: " ", expected: " ", actual: " ",
-                      configuration: version, version: version, notes: " ", attachments: [], area: lastArea)
+                      configuration: "", version: version, notes: "", attachments: [], area: lastArea)
 
         } catch let error {
             assertionFailure("Got unexpected error type \(error)")

--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -1224,13 +1224,16 @@ DQ
                                             <rect key="frame" x="1" y="1" width="570" height="68"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <textView importsGraphics="NO" richText="NO" usesFontPanel="YES" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" smartInsertDelete="YES" id="SKw-6e-Fyl" customClass="TextView" customModule="Brisk" customModuleProvider="target">
+                                                <textView importsGraphics="NO" richText="NO" usesFontPanel="YES" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" smartInsertDelete="YES" id="SKw-6e-Fyl" customClass="PlaceholderTextView" customModule="Brisk" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="570" height="68"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <size key="minSize" width="570" height="68"/>
                                                     <size key="maxSize" width="572" height="10000000"/>
                                                     <color key="insertionPointColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="placeholderString" value="optional"/>
+                                                    </userDefinedRuntimeAttributes>
                                                 </textView>
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -1270,7 +1273,7 @@ DQ
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="Kdd-Ld-WJr"/>
                                 </constraints>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="" drawsBackground="YES" id="dyf-rd-otk">
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="optional" drawsBackground="YES" id="dyf-rd-otk">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Brisk/Views/PlaceholderTextView.swift
+++ b/Brisk/Views/PlaceholderTextView.swift
@@ -1,0 +1,12 @@
+import AppKit
+
+final class PlaceholderTextView: TextView {
+    @IBInspectable var placeholderString: String?
+
+    // Show a placeholder using the private API from NSTextView
+    // https://stackoverflow.com/a/43028577/902968
+    @objc
+    private var placeholderAttributedString: NSAttributedString? {
+        return self.placeholderString.map(NSAttributedString.init)
+    }
+}

--- a/Brisk/Views/TextView.swift
+++ b/Brisk/Views/TextView.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-final class TextView: NSTextView {
+class TextView: NSTextView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
 

--- a/BriskTests/OpenRadarTests.swift
+++ b/BriskTests/OpenRadarTests.swift
@@ -13,7 +13,7 @@ final class OpenRadarTests: XCTestCase {
         XCTAssertEqual(radar.product, .DeveloperTools)
         XCTAssertEqual(radar.reproducibility, .Always)
         XCTAssertEqual(radar.version, "Xcode 9.0")
-        XCTAssertEqual(radar.configuration, "Xcode 9.0")
+        XCTAssertEqual(radar.configuration, "")
         XCTAssertEqual(radar.title, "Some title")
         XCTAssertEqual(radar.description, "This is a duplicate of radar #1234\n\nfoo\n\nbar\nbaz\n")
         XCTAssertEqual(radar.steps, "1. foo\n2. bar")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   [issue](https://github.com/br1sk/brisk/issues/15)
   [change](https://github.com/br1sk/brisk/pull/84)
 
+- Make Configuration and Notes optional
+  [issue](https://github.com/br1sk/brisk/issues/46)
+  [change](https://github.com/br1sk/brisk/pull/86)
+
 ## Bug Fixes
 
 - Typing emoji caused font to change


### PR DESCRIPTION
This mirrors the required / optional behavior from radarweb. I haven't
checked the "API" to see if any other fields are accepted as empty, even
though they are required in the radar UI, but I think matching that
behavior makes sense.