### PR TITLE
Only update title with valid title text

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -248,8 +248,12 @@ final class RadarViewController: ViewController {
     }
 
     fileprivate func updateTitleFromDocument() {
-        let newTitle = self.titleTextField.stringValue
-        self.document?.displayName = newTitle
+        let title = self.titleTextField.stringValue
+        if title.isEmpty {
+            return
+        }
+
+        self.document?.displayName = title
         self.windowController?.synchronizeWindowTitleWithDocumentName()
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,6 @@
 - Focus existing windows when reopening documents
   [issue](https://github.com/br1sk/brisk/issues/48)
   [change](https://github.com/br1sk/brisk/issues/80)
+
+- Only update window title on title text change
+  [change](https://github.com/br1sk/brisk/pull/87)


### PR DESCRIPTION
Right now whenever you type anything in any field we wipe out the title
field. We should only update the title when the title text is non-empty.
I would set the document's title to nil when you delete it, but if you
do that you end up with a document named "Untitled -1" which then syncs
with the window's title bar and seems crazy.