### PR TITLE
Register file change for duplicates

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -66,6 +66,10 @@ final class RadarViewController: ViewController {
     }
 
     func restore(_ radar: Radar) {
+        if self.document?.fileURL == nil {
+            self.document?.updateChangeCount(.changeDone)
+        }
+
         self.classificationPopUp.selectItem(withTitle: radar.classification.name)
         self.reproducibilityPopUp.selectItem(withTitle: radar.reproducibility.name)
         self.productPopUp.selectItem(withTitle: radar.product.name)

--- a/Brisk/Models/RadarDocument.swift
+++ b/Brisk/Models/RadarDocument.swift
@@ -27,11 +27,11 @@ final class RadarDocument: NSDocument {
 
     func makeWindowControllers(for radar: Radar?) {
         let windowController = NSStoryboard.main.instantiateWindowController(identifier: "Radar")
+        self.addWindowController(windowController)
+
         if let radar = radar {
             let viewController = windowController.contentViewController as! RadarViewController
             viewController.restore(radar)
         }
-
-        self.addWindowController(windowController)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   [issue](https://github.com/br1sk/brisk/issues/46)
   [change](https://github.com/br1sk/brisk/pull/86)
 
+- Mark duplicate radars as dirty documents
+  [change](https://github.com/br1sk/brisk/pull/88)
+
 ## Bug Fixes
 
 - Typing emoji caused font to change


### PR DESCRIPTION
When restoring a Radar that doesn't have an associated URL, mark the
document as dirty.