### PR TITLE
Add ability to remove attachment

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -16,7 +16,7 @@ final class RadarViewController: ViewController {
     @IBOutlet private var submitButton: NSButton!
     @IBOutlet private var titleTextField: NSTextField!
     @IBOutlet private var versionTextField: NSTextField!
-    @IBOutlet private var addAttachmentButton: NSButton!
+    @IBOutlet private var toggleAttachmentButton: NSButton!
     @IBOutlet private var attachmentTextField: NSTextField!
 
     private var attachments: [Attachment] = [] {
@@ -26,7 +26,7 @@ final class RadarViewController: ViewController {
             }
 
             let attachment = self.attachments.first
-            self.addAttachmentButton.isEnabled = attachment == nil
+            self.toggleAttachmentButton.title = attachment == nil ? "Add Attachment" : "Remove Attachment"
             self.attachmentTextField.stringValue = attachment?.filename ?? "No Attachment"
         }
     }
@@ -165,11 +165,21 @@ final class RadarViewController: ViewController {
         self.updateAreas(with: product)
     }
 
-    @IBAction private func addAttachment(_ sender: NSButton) {
-        guard let window = self.view.window else {
+    @IBAction private func toggleAttachment(_ sender: NSButton) {
+        if !self.attachments.isEmpty {
+            self.attachments = []
             return
         }
 
+        guard let window = self.view.window else {
+            assertionFailure("Adding attachment with no window")
+            return
+        }
+
+        self.addAttachment(to: window)
+    }
+
+    private func addAttachment(to window: NSWindow) {
         let panel = NSOpenPanel()
         panel.beginSheetModal(for: window) { [weak panel] response in
             guard response == NSFileHandlingPanelOKButton, let url = panel?.urls.first else {

--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -1413,7 +1413,7 @@ DQ
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="addAttachment:" target="HUy-04-wVn" id="vDZ-jT-1YF"/>
+                                    <action selector="toggleAttachment:" target="HUy-04-wVn" id="BAJ-Lk-IxX"/>
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nzj-cZ-RzB">
@@ -1488,7 +1488,6 @@ DQ
                     </view>
                     <connections>
                         <outlet property="actualTextView" destination="uI0-Jp-4xg" id="bzD-50-xx6"/>
-                        <outlet property="addAttachmentButton" destination="jeH-OT-VUN" id="5D2-U2-Gjn"/>
                         <outlet property="areaPopUp" destination="X7m-L6-qiF" id="XY9-IN-VrL"/>
                         <outlet property="attachmentTextField" destination="nzj-cZ-RzB" id="XmX-T6-yJQ"/>
                         <outlet property="classificationPopUp" destination="DnJ-2X-9qh" id="m4n-EI-uF1"/>
@@ -1502,6 +1501,7 @@ DQ
                         <outlet property="stepsTextView" destination="NFX-5c-vMY" id="7jy-wZ-O4y"/>
                         <outlet property="submitButton" destination="EfJ-B0-TXm" id="Jqo-CF-Tta"/>
                         <outlet property="titleTextField" destination="waP-Aq-0Oq" id="0Ge-ln-dHN"/>
+                        <outlet property="toggleAttachmentButton" destination="jeH-OT-VUN" id="FrD-5p-Hay"/>
                         <outlet property="versionTextField" destination="w1D-nw-4Gs" id="oFq-lg-mZC"/>
                     </connections>
                 </viewController>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 - Mark duplicate radars as dirty documents
   [change](https://github.com/br1sk/brisk/pull/88)
 
+- Add ability to remove attachment
+  [issue](https://github.com/br1sk/brisk/issues/16)
+  [change](https://github.com/br1sk/brisk/pull/89)
+
 ## Bug Fixes
 
 - Typing emoji caused font to change


### PR DESCRIPTION
This turns what was previously the "Add Attachment" button into a toggle
attachment button where it either adds or removes the attachment based
on if you already have one.