### PR TITLE
Reset change count when loading radar

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -89,6 +89,7 @@ final class RadarViewController: ViewController {
         self.attachments = radar.attachments
 
         self.enableSubmitIfValid()
+        self.document?.updateChangeCount(.changeCleared)
     }
 
     func currentRadar() -> Radar {
@@ -207,7 +208,7 @@ final class RadarViewController: ViewController {
                 self.document?.save(self)
             }
 
-            self.view.window?.close()
+            self.document?.close()
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ## Bug Fixes
 
-- None.
+- Don't register dup'd radars as dirty files
+  [change](https://github.com/br1sk/brisk/pull/103)
 
 # 1.0.1
 


### PR DESCRIPTION
Previously if you started to dup a radar, we filled in all the fields in
the window, which sets the document change count to edited. Then if you
closed the window, you would be prompted to save the document. In this
case where you haven't edited anything, the document will be immediately
closable and you will only be prompted to save the document if you make
changes to it.