### PR TITLE
Update the title when restoring a radar

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -89,6 +89,7 @@ final class RadarViewController: ViewController {
         self.attachments = radar.attachments
 
         self.enableSubmitIfValid()
+        self.updateTitleFromDocument()
         self.document?.updateChangeCount(.changeCleared)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Don't register dup'd radars as dirty files
   [change](https://github.com/br1sk/brisk/pull/103)
 
+- Update the title when restoring a radar
+  [change](https://github.com/br1sk/brisk/pull/104)
+
 # 1.0.1
 
 ## Enhancements


### PR DESCRIPTION
Previously if you were duping a radar, when the window was populated the
title was out of sync with the content. Then the first time you
interacted with the fields, the title would sync. Now it syncs
immediately.