### PR TITLE
Add checkbox for crossposting to open radar

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -18,6 +18,7 @@ final class RadarViewController: ViewController {
     @IBOutlet private var versionTextField: NSTextField!
     @IBOutlet private var toggleAttachmentButton: NSButton!
     @IBOutlet private var attachmentTextField: NSTextField!
+    @IBOutlet private var postToOpenRadarButton: NSButton!
 
     private var attachments: [Attachment] = [] {
         didSet {
@@ -63,6 +64,11 @@ final class RadarViewController: ViewController {
 
         let product = Product.All.first { $0.name == self.productPopUp.selectedTitle }!
         self.updateAreas(with: product)
+    }
+
+    override func viewWillAppear() {
+        super.viewWillAppear()
+        self.view.window?.delegate = self
     }
 
     func restore(_ radar: Radar) {
@@ -135,7 +141,9 @@ final class RadarViewController: ViewController {
         { [weak self] result in
             switch result {
                 case .success(let radarID):
-                    guard let (_, token) = Keychain.get(.openRadar) else {
+                    guard self?.postToOpenRadarButton.state == NSOnState,
+                        let (_, token) = Keychain.get(.openRadar) else
+                    {
                         self?.submitRadarCompletion(success: true)
                         return
                     }
@@ -255,6 +263,16 @@ final class RadarViewController: ViewController {
         field.becomeFirstResponder()
     }
 
+    fileprivate func updateOpenRadarButton() {
+        let canPostToOpenRadar = Keychain.get(.openRadar) != nil
+        self.postToOpenRadarButton.isEnabled = canPostToOpenRadar
+        self.postToOpenRadarButton.toolTip = canPostToOpenRadar ? nil : "Open Preferences to add an account"
+
+        if !canPostToOpenRadar {
+            self.postToOpenRadarButton.state = NSOffState
+        }
+    }
+
     fileprivate func enableSubmitIfValid() {
         let isValid = self.validatables.reduce(true) { valid, validatable in
             return valid && validatable.isValid
@@ -303,5 +321,11 @@ extension RadarViewController: NSTextViewDelegate {
         for textView in self.textViews {
             textView.delegate = self
         }
+    }
+}
+
+extension RadarViewController: NSWindowDelegate {
+    func windowDidBecomeKey(_ notification: Notification) {
+        self.updateOpenRadarButton()
     }
 }

--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -1434,9 +1434,6 @@ DQ
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="OHe-Ov-n1g">
-                                <rect key="frame" x="590" y="23" width="16" height="16"/>
-                            </progressIndicator>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jeH-OT-VUN">
                                 <rect key="frame" x="108" y="13" width="138" height="32"/>
                                 <buttonCell key="cell" type="push" title="Add Attachment" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5oh-VJ-yEg">
@@ -1448,7 +1445,7 @@ DQ
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nzj-cZ-RzB">
-                                <rect key="frame" x="246" y="23" width="338" height="17"/>
+                                <rect key="frame" x="246" y="23" width="190" height="17"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="No Attachment" id="C9t-RF-qkI">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1463,6 +1460,16 @@ DQ
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="Dn1-lF-Xzt">
+                                <rect key="frame" x="464" y="22" width="144" height="18"/>
+                                <buttonCell key="cell" type="check" title="Send to Open Radar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="N4k-be-Zct">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                            </button>
+                            <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="OHe-Ov-n1g">
+                                <rect key="frame" x="442" y="23" width="16" height="16"/>
+                            </progressIndicator>
                         </subviews>
                         <constraints>
                             <constraint firstItem="A2T-ef-XlO" firstAttribute="trailing" secondItem="6TN-hx-g1I" secondAttribute="trailing" id="0TQ-8A-cL1"/>
@@ -1472,7 +1479,6 @@ DQ
                             <constraint firstItem="w1D-nw-4Gs" firstAttribute="baseline" secondItem="tzm-FL-SCJ" secondAttribute="baseline" id="6Ny-Pl-Gdz"/>
                             <constraint firstItem="slV-6o-OdD" firstAttribute="baseline" secondItem="l3V-hh-I5h" secondAttribute="baseline" id="6zg-Qf-jWU"/>
                             <constraint firstItem="Ot3-1l-AkT" firstAttribute="trailing" secondItem="87y-BM-XPm" secondAttribute="trailing" id="8CO-Gt-tmD"/>
-                            <constraint firstItem="OHe-Ov-n1g" firstAttribute="leading" secondItem="nzj-cZ-RzB" secondAttribute="trailing" constant="8" symbolic="YES" id="8sw-fx-ZD9"/>
                             <constraint firstItem="Ws1-0o-O0p" firstAttribute="leading" secondItem="5dM-wd-a3b" secondAttribute="trailing" constant="8" id="AuI-G6-tHH"/>
                             <constraint firstItem="416-1P-0H2" firstAttribute="leading" secondItem="lwO-Mw-YFg" secondAttribute="trailing" constant="8" id="Ay5-9E-BS5"/>
                             <constraint firstItem="lwO-Mw-YFg" firstAttribute="trailing" secondItem="bkT-Mr-Eu5" secondAttribute="trailing" id="BUr-2h-w3H"/>
@@ -1480,6 +1486,7 @@ DQ
                             <constraint firstItem="tzm-FL-SCJ" firstAttribute="trailing" secondItem="slV-6o-OdD" secondAttribute="trailing" id="CAT-gV-k3l"/>
                             <constraint firstItem="jeH-OT-VUN" firstAttribute="leading" secondItem="SKw-6e-Fyl" secondAttribute="leading" id="D8s-eW-I8D"/>
                             <constraint firstItem="hDj-mq-FR4" firstAttribute="width" secondItem="w1D-nw-4Gs" secondAttribute="width" id="DI9-Pq-sFP"/>
+                            <constraint firstItem="Dn1-lF-Xzt" firstAttribute="leading" secondItem="OHe-Ov-n1g" secondAttribute="trailing" constant="8" symbolic="YES" id="Dl8-0L-egs"/>
                             <constraint firstItem="DnJ-2X-9qh" firstAttribute="leading" secondItem="bkT-Mr-Eu5" secondAttribute="trailing" constant="8" id="FAL-1x-Z3K"/>
                             <constraint firstItem="tso-uy-kbf" firstAttribute="trailing" secondItem="Snb-fM-qhI" secondAttribute="trailing" id="FuG-Ob-bky"/>
                             <constraint firstItem="DnJ-2X-9qh" firstAttribute="baseline" secondItem="bkT-Mr-Eu5" secondAttribute="baseline" id="HTL-3D-geU"/>
@@ -1493,15 +1500,16 @@ DQ
                             <constraint firstItem="OHe-Ov-n1g" firstAttribute="centerY" secondItem="EfJ-B0-TXm" secondAttribute="centerY" id="RVn-FP-BBM"/>
                             <constraint firstItem="lwO-Mw-YFg" firstAttribute="baseline" secondItem="waP-Aq-0Oq" secondAttribute="baseline" id="Sra-iI-Riv"/>
                             <constraint firstItem="xl3-yf-7kD" firstAttribute="trailing" secondItem="A2T-ef-XlO" secondAttribute="trailing" id="SzL-lo-o7p"/>
+                            <constraint firstItem="EfJ-B0-TXm" firstAttribute="leading" secondItem="Dn1-lF-Xzt" secondAttribute="trailing" constant="8" symbolic="YES" id="WZm-Pt-jKF"/>
                             <constraint firstItem="tso-uy-kbf" firstAttribute="top" secondItem="Snb-fM-qhI" secondAttribute="bottom" constant="2" id="WjR-4c-pgR"/>
                             <constraint firstItem="X7m-L6-qiF" firstAttribute="width" secondItem="Ws1-0o-O0p" secondAttribute="width" id="XmE-Pi-c0s"/>
                             <constraint firstItem="EfJ-B0-TXm" firstAttribute="top" secondItem="416-1P-0H2" secondAttribute="bottom" constant="8" id="Yzj-BA-LTb"/>
                             <constraint firstItem="416-1P-0H2" firstAttribute="top" secondItem="QUk-rv-IAw" secondAttribute="bottom" constant="8" id="aV2-G8-MYD"/>
                             <constraint firstItem="hDj-mq-FR4" firstAttribute="leading" secondItem="slV-6o-OdD" secondAttribute="trailing" constant="8" id="b4Y-Gx-oAF"/>
-                            <constraint firstItem="EfJ-B0-TXm" firstAttribute="leading" secondItem="OHe-Ov-n1g" secondAttribute="trailing" constant="8" id="bLn-Ix-cVH"/>
                             <constraint firstItem="5dM-wd-a3b" firstAttribute="top" secondItem="OBM-6V-JDI" secondAttribute="top" constant="20" id="bgL-zm-mS0"/>
                             <constraint firstItem="nzj-cZ-RzB" firstAttribute="leading" secondItem="jeH-OT-VUN" secondAttribute="trailing" constant="8" symbolic="YES" id="fMY-wC-gSK"/>
                             <constraint firstItem="5dM-wd-a3b" firstAttribute="trailing" secondItem="bkT-Mr-Eu5" secondAttribute="trailing" id="fQn-ru-RqY"/>
+                            <constraint firstItem="Dn1-lF-Xzt" firstAttribute="baseline" secondItem="nzj-cZ-RzB" secondAttribute="baseline" id="fY0-vf-Wav"/>
                             <constraint firstItem="6TN-hx-g1I" firstAttribute="top" secondItem="StP-3g-DTl" secondAttribute="bottom" constant="62" id="ffC-tg-aMC"/>
                             <constraint firstItem="Wsr-Nw-FTS" firstAttribute="top" secondItem="6TN-hx-g1I" secondAttribute="top" id="geR-58-b8b"/>
                             <constraint firstItem="l3V-hh-I5h" firstAttribute="leading" secondItem="X7m-L6-qiF" secondAttribute="leading" id="gjH-8M-TUZ"/>
@@ -1510,6 +1518,7 @@ DQ
                             <constraint firstItem="X7m-L6-qiF" firstAttribute="leading" secondItem="Ot3-1l-AkT" secondAttribute="trailing" constant="8" id="ihj-zO-9X5"/>
                             <constraint firstItem="snB-5I-Qzt" firstAttribute="top" secondItem="A2T-ef-XlO" secondAttribute="top" id="jfD-7D-GUC"/>
                             <constraint firstItem="dIk-Cy-HfV" firstAttribute="top" secondItem="xl3-yf-7kD" secondAttribute="top" id="kdN-GS-OGD"/>
+                            <constraint firstItem="OHe-Ov-n1g" firstAttribute="leading" secondItem="nzj-cZ-RzB" secondAttribute="trailing" constant="8" symbolic="YES" id="lVM-LM-zOv"/>
                             <constraint firstItem="l3V-hh-I5h" firstAttribute="width" secondItem="X7m-L6-qiF" secondAttribute="width" id="mdJ-ip-hJx"/>
                             <constraint firstItem="87y-BM-XPm" firstAttribute="baseline" secondItem="DnJ-2X-9qh" secondAttribute="baseline" id="pjO-bp-IdP"/>
                             <constraint firstItem="jeH-OT-VUN" firstAttribute="centerY" secondItem="EfJ-B0-TXm" secondAttribute="centerY" id="psv-xN-J2d"/>
@@ -1536,6 +1545,7 @@ DQ
                         <outlet property="descriptionTextView" destination="WH8-h7-UQ2" id="9r3-Hm-3IV"/>
                         <outlet property="expectedTextView" destination="Y7a-Qh-n0G" id="QPS-dh-uw2"/>
                         <outlet property="notesTextView" destination="SKw-6e-Fyl" id="iUf-te-paN"/>
+                        <outlet property="postToOpenRadarButton" destination="Dn1-lF-Xzt" id="hxu-Ex-cft"/>
                         <outlet property="productPopUp" destination="Ws1-0o-O0p" id="LBH-Er-64a"/>
                         <outlet property="progressIndicator" destination="OHe-Ov-n1g" id="yeE-KM-aIo"/>
                         <outlet property="reproducibilityPopUp" destination="l3V-hh-I5h" id="da9-Gz-dl6"/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Enhancements
 
-- None.
+- Add checkbox to control crossposting to open radar
+  [issue](https://github.com/br1sk/brisk/issues/4)
+  [change](https://github.com/br1sk/brisk/pull/107)
 
 ## Bug Fixes
 


### PR DESCRIPTION
This adds a checkbox in each window for whether or not the current radar
should be cross posted to open radar. This is useful for when you want
to keep a radar private, or you just don't want to cross post a
duplicate to open radar.

This won't scale if we want to allow:

- only posting to openradar (perhaps if you just want to post something
you've already posted to apple radar)
- support for more services

But in the meantime I think having a way to customize this is important
so it's worth adding this way for now.