### PR TITLE
Remove unnecessary change count change

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -66,10 +66,6 @@ final class RadarViewController: ViewController {
     }
 
     func restore(_ radar: Radar) {
-        if self.document?.fileURL == nil {
-            self.document?.updateChangeCount(.changeDone)
-        }
-
         self.classificationPopUp.selectItem(withTitle: radar.classification.name)
         self.reproducibilityPopUp.selectItem(withTitle: radar.reproducibility.name)
         self.productPopUp.selectItem(withTitle: radar.product.name)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Update the title when restoring a radar
   [change](https://github.com/br1sk/brisk/pull/104)
 
+- Remove unnecessary change count +1
+  [change](https://github.com/br1sk/brisk/pull/108)
+
 # 1.0.1
 
 ## Enhancements


### PR DESCRIPTION
Below this we cleared all changes because of the newer change behavior,
so this isn't necessary.