### PR TITLE
Add attachment drag and drop support

### DIFF
--- a/Brisk.xcodeproj/project.pbxproj
+++ b/Brisk.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1BA2CE444CBF0C961AEF74B3 /* Pods_Brisk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88425AC44C8AB4389F2A583 /* Pods_Brisk.framework */; };
+		493890561F157F16008F9E94 /* AttachmentDroppableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493890551F157F16008F9E94 /* AttachmentDroppableView.swift */; };
 		BADCFD626E46B81044A115B2 /* Pods_BriskTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0018868F17477C7D609957AD /* Pods_BriskTests.framework */; };
 		C2042B531D17397900DEF594 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2042B521D17397900DEF594 /* ViewController.swift */; };
 		C20DDC121D16496E0086D304 /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20DDC111D16496E0086D304 /* AuthenticationViewController.swift */; };
@@ -76,6 +77,7 @@
 /* Begin PBXFileReference section */
 		0018868F17477C7D609957AD /* Pods_BriskTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BriskTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		45F9233FBE2D1D0D4ABF530C /* Pods-Brisk.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Brisk.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Brisk/Pods-Brisk.debug.xcconfig"; sourceTree = "<group>"; };
+		493890551F157F16008F9E94 /* AttachmentDroppableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentDroppableView.swift; sourceTree = "<group>"; };
 		7DD69D9F6507E9D3006DC976 /* Pods-BriskTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BriskTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BriskTests/Pods-BriskTests.release.xcconfig"; sourceTree = "<group>"; };
 		9002A6E26E9C2D617DFB9460 /* Pods-Brisk.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Brisk.release.xcconfig"; path = "Pods/Target Support Files/Pods-Brisk/Pods-Brisk.release.xcconfig"; sourceTree = "<group>"; };
 		C2042B521D17397900DEF594 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 		C2C042251EF6F781008BFC88 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				493890551F157F16008F9E94 /* AttachmentDroppableView.swift */,
 				C2C042261EF6F781008BFC88 /* TextView.swift */,
 			);
 			path = Views;
@@ -565,6 +568,7 @@
 				C2839A1B1D14F2E100D240C4 /* NSPopUpButton+Extension.swift in Sources */,
 				C27DBF241EF8F071007666C3 /* Radar+OpenRadar.swift in Sources */,
 				C219CBD81D173602002F89FC /* NSStatusItem+Extension.swift in Sources */,
+				493890561F157F16008F9E94 /* AttachmentDroppableView.swift in Sources */,
 				C2042B531D17397900DEF594 /* ViewController.swift in Sources */,
 				C2E8AE981D168A9200A65DB0 /* CascadingWindowController.swift in Sources */,
 				C27F3B721D8B239B00EA3B7D /* Constants.swift in Sources */,

--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -19,6 +19,7 @@ final class RadarViewController: ViewController {
     @IBOutlet private var toggleAttachmentButton: NSButton!
     @IBOutlet private var attachmentTextField: NSTextField!
     @IBOutlet private var postToOpenRadarButton: NSButton!
+    @IBOutlet private var attachmentDroppableView: AttachmentDroppableView!
 
     private var attachments: [Attachment] = [] {
         didSet {
@@ -61,6 +62,9 @@ final class RadarViewController: ViewController {
         self.classificationPopUp.setItems(titles: Classification.All.map { $0.name })
         self.reproducibilityPopUp.setItems(titles: Reproducibility.All.map { $0.name })
         self.productPopUp.set(items: Product.All, getTitle: { $0.name }, getGroup: { $0.category })
+        self.attachmentDroppableView.droppedAttachment = { [weak self] attachments in
+            self?.attachments = [attachments]
+        }
 
         let product = Product.All.first { $0.name == self.productPopUp.selectedTitle }!
         self.updateAreas(with: product)

--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -1434,6 +1434,9 @@ DQ
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wdf-dR-1TM" customClass="AttachmentDroppableView" customModule="Brisk" customModuleProvider="target">
+                                <rect key="frame" x="114" y="0.0" width="492" height="50"/>
+                            </customView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jeH-OT-VUN">
                                 <rect key="frame" x="108" y="13" width="138" height="32"/>
                                 <buttonCell key="cell" type="push" title="Add Attachment" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5oh-VJ-yEg">
@@ -1478,6 +1481,7 @@ DQ
                             <constraint firstItem="87y-BM-XPm" firstAttribute="leading" secondItem="DnJ-2X-9qh" secondAttribute="trailing" constant="8" id="4dL-pK-SgD"/>
                             <constraint firstItem="w1D-nw-4Gs" firstAttribute="baseline" secondItem="tzm-FL-SCJ" secondAttribute="baseline" id="6Ny-Pl-Gdz"/>
                             <constraint firstItem="slV-6o-OdD" firstAttribute="baseline" secondItem="l3V-hh-I5h" secondAttribute="baseline" id="6zg-Qf-jWU"/>
+                            <constraint firstItem="EfJ-B0-TXm" firstAttribute="leading" secondItem="Wdf-dR-1TM" secondAttribute="trailing" constant="8" symbolic="YES" id="7af-WX-NKI"/>
                             <constraint firstItem="Ot3-1l-AkT" firstAttribute="trailing" secondItem="87y-BM-XPm" secondAttribute="trailing" id="8CO-Gt-tmD"/>
                             <constraint firstItem="Ws1-0o-O0p" firstAttribute="leading" secondItem="5dM-wd-a3b" secondAttribute="trailing" constant="8" id="AuI-G6-tHH"/>
                             <constraint firstItem="416-1P-0H2" firstAttribute="leading" secondItem="lwO-Mw-YFg" secondAttribute="trailing" constant="8" id="Ay5-9E-BS5"/>
@@ -1491,8 +1495,10 @@ DQ
                             <constraint firstItem="tso-uy-kbf" firstAttribute="trailing" secondItem="Snb-fM-qhI" secondAttribute="trailing" id="FuG-Ob-bky"/>
                             <constraint firstItem="DnJ-2X-9qh" firstAttribute="baseline" secondItem="bkT-Mr-Eu5" secondAttribute="baseline" id="HTL-3D-geU"/>
                             <constraint firstItem="l3V-hh-I5h" firstAttribute="baseline" secondItem="DnJ-2X-9qh" secondAttribute="baseline" id="J13-CA-cGh"/>
+                            <constraint firstItem="Wdf-dR-1TM" firstAttribute="top" secondItem="SKw-6e-Fyl" secondAttribute="bottom" id="J4l-6k-fs0"/>
                             <constraint firstAttribute="trailing" secondItem="w1D-nw-4Gs" secondAttribute="trailing" constant="20" id="JCH-69-HmN"/>
                             <constraint firstItem="X7m-L6-qiF" firstAttribute="baseline" secondItem="Ot3-1l-AkT" secondAttribute="baseline" id="K0Y-vA-FEx"/>
+                            <constraint firstItem="Wdf-dR-1TM" firstAttribute="leading" secondItem="SKw-6e-Fyl" secondAttribute="leading" id="KJE-TI-bAP"/>
                             <constraint firstItem="tzm-FL-SCJ" firstAttribute="baseline" secondItem="X7m-L6-qiF" secondAttribute="baseline" id="LVr-O8-NLU"/>
                             <constraint firstItem="QUk-rv-IAw" firstAttribute="leading" secondItem="bkT-Mr-Eu5" secondAttribute="leading" id="McH-c7-sIJ"/>
                             <constraint firstItem="bkT-Mr-Eu5" firstAttribute="top" secondItem="5dM-wd-a3b" secondAttribute="bottom" constant="12" id="Per-1z-j8K"/>
@@ -1522,6 +1528,7 @@ DQ
                             <constraint firstItem="l3V-hh-I5h" firstAttribute="width" secondItem="X7m-L6-qiF" secondAttribute="width" id="mdJ-ip-hJx"/>
                             <constraint firstItem="87y-BM-XPm" firstAttribute="baseline" secondItem="DnJ-2X-9qh" secondAttribute="baseline" id="pjO-bp-IdP"/>
                             <constraint firstItem="jeH-OT-VUN" firstAttribute="centerY" secondItem="EfJ-B0-TXm" secondAttribute="centerY" id="psv-xN-J2d"/>
+                            <constraint firstAttribute="bottom" secondItem="Wdf-dR-1TM" secondAttribute="bottom" id="qKT-zy-axD"/>
                             <constraint firstAttribute="trailing" secondItem="416-1P-0H2" secondAttribute="trailing" constant="20" id="rEV-NQ-5TJ"/>
                             <constraint firstItem="Snb-fM-qhI" firstAttribute="trailing" secondItem="xl3-yf-7kD" secondAttribute="trailing" id="raX-we-DKR"/>
                             <constraint firstItem="StP-3g-DTl" firstAttribute="trailing" secondItem="lwO-Mw-YFg" secondAttribute="trailing" id="sFI-uR-53J"/>
@@ -1539,6 +1546,7 @@ DQ
                     <connections>
                         <outlet property="actualTextView" destination="uI0-Jp-4xg" id="bzD-50-xx6"/>
                         <outlet property="areaPopUp" destination="X7m-L6-qiF" id="XY9-IN-VrL"/>
+                        <outlet property="attachmentDroppableView" destination="Wdf-dR-1TM" id="AVy-jt-TQ7"/>
                         <outlet property="attachmentTextField" destination="nzj-cZ-RzB" id="XmX-T6-yJQ"/>
                         <outlet property="classificationPopUp" destination="DnJ-2X-9qh" id="m4n-EI-uF1"/>
                         <outlet property="configurationTextField" destination="hDj-mq-FR4" id="ML4-Qd-a7j"/>

--- a/Brisk/Views/AttachmentDroppableView.swift
+++ b/Brisk/Views/AttachmentDroppableView.swift
@@ -1,0 +1,49 @@
+import Cocoa
+import Sonar
+
+private enum AttachmentDropError: Error {
+    case noAttachments
+}
+
+final class AttachmentDroppableView: NSView {
+    /// Called with the dropped attachment after the drop has been completed
+    var droppedAttachment: ((Attachment) -> Void)!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.register(forDraggedTypes: [NSFilenamesPboardType])
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        do {
+            _ = try sender.getAttachments()
+            return .copy
+        } catch {
+            return []
+        }
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        do {
+            let attachments = try sender.getAttachments()
+            self.droppedAttachment(attachments.first!)
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+fileprivate extension NSDraggingInfo {
+    private var files: [String] {
+        return self.draggingPasteboard().propertyList(forType: NSFilenamesPboardType) as? [String] ?? []
+    }
+
+    fileprivate func getAttachments() throws -> [Attachment] {
+        if self.files.isEmpty {
+            throw AttachmentDropError.noAttachments
+        }
+
+        return try self.files.map { try Attachment(url: URL(fileURLWithPath: $0)) }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   [issue](https://github.com/br1sk/brisk/issues/4)
   [change](https://github.com/br1sk/brisk/pull/107)
 
+- Add drag and drop attachment support 
+  [issue](https://github.com/br1sk/brisk/issues/35)
+  [change](https://github.com/br1sk/brisk/pull/109)
+
 ## Bug Fixes
 
 - Don't register dup'd radars as dirty files


### PR DESCRIPTION
This allows you to drag and drop a single attachment onto the bottom of
the new radar UI

This supersedes https://github.com/br1sk/brisk/pull/102 and fixes https://github.com/br1sk/brisk/issues/35