### PR TITLE
Default posting to open radar to false when duping

### DIFF
--- a/Brisk/Controllers/RadarViewController.swift
+++ b/Brisk/Controllers/RadarViewController.swift
@@ -96,6 +96,7 @@ final class RadarViewController: ViewController {
 
         self.enableSubmitIfValid()
         self.updateTitleFromDocument()
+        self.postToOpenRadarButton.state = NSOffState
         self.document?.updateChangeCount(.changeCleared)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   [issue](https://github.com/br1sk/brisk/issues/35)
   [change](https://github.com/br1sk/brisk/pull/109)
 
+- Default cross posting to false for duplicates
+  [issue](https://github.com/br1sk/brisk/issues/106)
+  [change](https://github.com/br1sk/brisk/issues/110)
+
 ## Bug Fixes
 
 - Don't register dup'd radars as dirty files


### PR DESCRIPTION
This defaults the checkbox for crossposting to open radar to false when
you are:

1. Explicitly filing a duplicate
2. Opening a `*.brisk` file

You can of course check this checkbox if you actually want to cross post
it.

Fixes https://github.com/br1sk/brisk/issues/106