### PR TITLE
Remove constraint from text view

### DIFF
--- a/Brisk/Resources/Base.lproj/Main.storyboard
+++ b/Brisk/Resources/Base.lproj/Main.storyboard
@@ -1382,7 +1382,7 @@ DQ
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="EfJ-B0-TXm">
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EfJ-B0-TXm">
                                 <rect key="frame" x="608" y="13" width="83" height="32"/>
                                 <buttonCell key="cell" type="push" title="Submit" bezelStyle="rounded" alignment="center" enabled="NO" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3gP-J4-dT6">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1438,7 +1438,7 @@ DQ
                                 </constraints>
                             </customView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jeH-OT-VUN">
-                                <rect key="frame" x="108" y="13" width="138" height="32"/>
+                                <rect key="frame" x="107" y="13" width="138" height="32"/>
                                 <buttonCell key="cell" type="push" title="Add Attachment" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="5oh-VJ-yEg">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -1448,7 +1448,7 @@ DQ
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nzj-cZ-RzB">
-                                <rect key="frame" x="246" y="23" width="190" height="17"/>
+                                <rect key="frame" x="245" y="23" width="191" height="17"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="No Attachment" id="C9t-RF-qkI">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1488,7 +1488,6 @@ DQ
                             <constraint firstItem="lwO-Mw-YFg" firstAttribute="trailing" secondItem="bkT-Mr-Eu5" secondAttribute="trailing" id="BUr-2h-w3H"/>
                             <constraint firstItem="slV-6o-OdD" firstAttribute="leading" secondItem="l3V-hh-I5h" secondAttribute="trailing" constant="8" id="Bsg-s2-5Xz"/>
                             <constraint firstItem="tzm-FL-SCJ" firstAttribute="trailing" secondItem="slV-6o-OdD" secondAttribute="trailing" id="CAT-gV-k3l"/>
-                            <constraint firstItem="jeH-OT-VUN" firstAttribute="leading" secondItem="SKw-6e-Fyl" secondAttribute="leading" id="D8s-eW-I8D"/>
                             <constraint firstItem="hDj-mq-FR4" firstAttribute="width" secondItem="w1D-nw-4Gs" secondAttribute="width" id="DI9-Pq-sFP"/>
                             <constraint firstItem="Dn1-lF-Xzt" firstAttribute="leading" secondItem="OHe-Ov-n1g" secondAttribute="trailing" constant="8" symbolic="YES" id="Dl8-0L-egs"/>
                             <constraint firstItem="DnJ-2X-9qh" firstAttribute="leading" secondItem="bkT-Mr-Eu5" secondAttribute="trailing" constant="8" id="FAL-1x-Z3K"/>
@@ -1520,6 +1519,7 @@ DQ
                             <constraint firstItem="l3V-hh-I5h" firstAttribute="leading" secondItem="X7m-L6-qiF" secondAttribute="leading" id="gjH-8M-TUZ"/>
                             <constraint firstItem="bkT-Mr-Eu5" firstAttribute="leading" secondItem="OBM-6V-JDI" secondAttribute="leading" constant="20" id="gyU-66-kyS"/>
                             <constraint firstItem="w1D-nw-4Gs" firstAttribute="leading" secondItem="tzm-FL-SCJ" secondAttribute="trailing" constant="8" id="h2X-4z-jD9"/>
+                            <constraint firstItem="jeH-OT-VUN" firstAttribute="leading" secondItem="416-1P-0H2" secondAttribute="leading" id="het-1v-ptm"/>
                             <constraint firstItem="X7m-L6-qiF" firstAttribute="leading" secondItem="Ot3-1l-AkT" secondAttribute="trailing" constant="8" id="ihj-zO-9X5"/>
                             <constraint firstItem="snB-5I-Qzt" firstAttribute="top" secondItem="A2T-ef-XlO" secondAttribute="top" id="jfD-7D-GUC"/>
                             <constraint firstItem="dIk-Cy-HfV" firstAttribute="top" secondItem="xl3-yf-7kD" secondAttribute="top" id="kdN-GS-OGD"/>


### PR DESCRIPTION
This removes the final constraint to the text views inside the stack
view. It seems like AppKit doesn't like things being constrained inside
here, or I'm just missing what's wrong with it, so hopefully this helps
with some layout issues.