### PR TITLE
Remove whitespace from appleIDTextField

### DIFF
--- a/Brisk/Controllers/AuthenticationViewController.swift
+++ b/Brisk/Controllers/AuthenticationViewController.swift
@@ -22,7 +22,7 @@ final class AuthenticationViewController: ViewController {
     // MARK: - Private Methods
 
     @IBAction private func login(_ sender: Any) {
-        let username = self.appleIDTextField.stringValue
+        let username = self.appleIDTextField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         let password = self.passwordTextField.stringValue
         Keychain.set(username: username, password: password, forKey: .radar)
         StoryboardRouter.reloadTopWindowController()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 
 ## Bug Fixes
 
-- None.
+- Remove whitespace from Apple ID login
+ +  [issue](https://github.com/br1sk/brisk/issues/133)
+ +  [change](https://github.com/br1sk/brisk/pull/134)
 
 # 1.1.2
 


### PR DESCRIPTION
Fixes #133 

Turns out that when using my text expander app for the email it adds a space at the end which causes authentication to fail.